### PR TITLE
Propagate UploadToken from TestAgent to TestSession object

### DIFF
--- a/samples/ConsoleAppTesting/ConsoleAppTesting.csproj
+++ b/samples/ConsoleAppTesting/ConsoleAppTesting.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>CA2007;CA1812</NoWarn>
+    <NoWarn>CA2007;CA1812;CA1515</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/samples/IntegrationTesting/IntegrationTesting.csproj
+++ b/samples/IntegrationTesting/IntegrationTesting.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>CA2007;CA1812;CA1010</NoWarn>
+    <NoWarn>CA2007;CA1812;CA1515;CA1010</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ProductionTests/ProductionTests.csproj
+++ b/samples/ProductionTests/ProductionTests.csproj
@@ -8,7 +8,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 
-    <NoWarn>CA2007</NoWarn>
+    <NoWarn>CA2007;CA1515</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/WebApp/WebApp.csproj
+++ b/samples/WebApp/WebApp.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-WebApp-cf00d0f9-6c3b-4e8f-ac53-a75cf8ff315e</UserSecretsId>
+    <NoWarn>CA1515</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xping.Sdk.Core/Session/ITestSessionBuilder.cs
+++ b/src/Xping.Sdk.Core/Session/ITestSessionBuilder.cs
@@ -78,7 +78,10 @@ public interface ITestSessionBuilder
     /// <summary>
     /// Gets the test session.
     /// </summary>
+    /// <param name="uploadToken">
+    /// The upload token that links the TestAgent's results to the project configured on the server.
+    /// </param>
     /// <returns>The test session.</returns>
-    TestSession GetTestSession();
+    TestSession GetTestSession(Guid uploadToken);
 }
 

--- a/src/Xping.Sdk.Core/Session/TestSession.cs
+++ b/src/Xping.Sdk.Core/Session/TestSession.cs
@@ -44,6 +44,12 @@ public sealed class TestSession :
     public Guid Id { get; private set; }
 
     /// <summary>
+    /// Gets the upload token for the test session that links the TestAgent's results to the project configured on 
+    /// the server.
+    /// </summary>
+    public Guid UploadToken { get; internal set; }
+
+    /// <summary>
     /// A Uri object that represents the URL of the page being validated.
     /// </summary>
     public required Uri Url

--- a/src/Xping.Sdk.Core/Session/TestSessionBuilder.cs
+++ b/src/Xping.Sdk.Core/Session/TestSessionBuilder.cs
@@ -217,8 +217,11 @@ public class TestSessionBuilder : ITestSessionBuilder
     /// <summary>
     /// Gets the test session.
     /// </summary>
+    /// <param name="uploadToken">
+    /// The upload token that links the TestAgent's results to the project configured on the server.
+    /// </param>
     /// <returns>The test session.</returns>
-    public TestSession GetTestSession()
+    public TestSession GetTestSession(Guid uploadToken)
     {
         try
         {
@@ -234,7 +237,8 @@ public class TestSessionBuilder : ITestSessionBuilder
                 Steps = _steps,
                 // Set the test session status to completed to indicate that no further modifications are allowed.
                 State = TestSessionState.Completed,
-                DeclineReason = null
+                DeclineReason = null,
+                UploadToken = uploadToken
             };
 
             return session;
@@ -247,7 +251,8 @@ public class TestSessionBuilder : ITestSessionBuilder
                 StartDate = _startDate < DateTime.UtcNow ? DateTime.UtcNow : _startDate,
                 Steps = _steps,
                 State = TestSessionState.Declined,
-                DeclineReason = ex.Message
+                DeclineReason = ex.Message,
+                UploadToken = uploadToken
             };
 
             return session;

--- a/src/Xping.Sdk.Core/TestAgent.cs
+++ b/src/Xping.Sdk.Core/TestAgent.cs
@@ -165,13 +165,6 @@ public class TestAgent : IDisposable
         }
 
         TestSession testSession = sessionBuilder.GetTestSession(uploadToken: _uploadToken);
-
-        TestSessionUploader uploader = new();
-        if (!string.IsNullOrWhiteSpace(UploadToken))
-        {
-            await uploader.UploadAsync(testSession, cancellationToken).ConfigureAwait(false);
-        }
-
         return testSession;
     }
 

--- a/src/Xping.Sdk.Core/TestAgent.cs
+++ b/src/Xping.Sdk.Core/TestAgent.cs
@@ -1,7 +1,15 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿/*
+ * © 2024 Xping.io. All Rights Reserved.
+ * This file is part of the Xping SDK. 
+ * 
+ * License: [MIT]
+ */
+
+using Microsoft.Extensions.DependencyInjection;
 using Xping.Sdk.Core.Components;
 using Xping.Sdk.Core.Session;
 using Xping.Sdk.Core.Common;
+using Xping.Sdk.Core.Session.Collector;
 
 namespace Xping.Sdk.Core;
 
@@ -63,7 +71,7 @@ public class TestAgent : IDisposable
     {
         // Initialize the container for each thread.
         return new Pipeline($"Pipeline#Thread[{Thread.CurrentThread.Name}:{Environment.CurrentManagedThreadId}]");
-    });
+    }); 
 
     /// <summary>
     /// Controls whether the TestAgent's pipeline container object should be instantiated for each thread separately.
@@ -156,7 +164,13 @@ public class TestAgent : IDisposable
             sessionBuilder.Build(agent: this, error: Errors.ExceptionError(ex));
         }
 
-        TestSession testSession = sessionBuilder.GetTestSession();
+        TestSession testSession = sessionBuilder.GetTestSession(uploadToken: _uploadToken);
+
+        TestSessionUploader uploader = new();
+        if (!string.IsNullOrWhiteSpace(UploadToken))
+        {
+            await uploader.UploadAsync(testSession, cancellationToken).ConfigureAwait(false);
+        }
 
         return testSession;
     }

--- a/src/Xping.Sdk.Core/Xping.Sdk.Core.csproj
+++ b/src/Xping.Sdk.Core/Xping.Sdk.Core.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.1" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.41.2" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Xping.Sdk.IntegrationTests" />

--- a/src/Xping.Sdk/Validations/Content/Page/Internals/InstrumentedFrameLocator.cs
+++ b/src/Xping.Sdk/Validations/Content/Page/Internals/InstrumentedFrameLocator.cs
@@ -13,9 +13,13 @@ internal class InstrumentedFrameLocator(TestContext context, IFrameLocator locat
     private readonly TestContext _context = context.RequireNotNull(nameof(context));
     private readonly IFrameLocator _locator = locator.RequireNotNull(nameof(locator));
 
-    public IFrameLocator First => new InstrumentedFrameLocator(_context, First);
+    [Obsolete("This method is obsolete in Playwright library. Use the 'ActiveLocator' property instead.")]
+    public IFrameLocator First => new InstrumentedFrameLocator(_context, _locator.First);
 
-    public IFrameLocator Last => new InstrumentedFrameLocator(_context, Last);
+    [Obsolete("This method is obsolete in Playwright library. Use the 'ActiveLocator' property instead.")]
+    public IFrameLocator Last => new InstrumentedFrameLocator(_context, _locator.Last);
+
+    public ILocator Owner => new InstrumentedLocator(_context, _locator.Owner);
 
     public IFrameLocator FrameLocator(string selector)
     {
@@ -379,6 +383,7 @@ internal class InstrumentedFrameLocator(TestContext context, IFrameLocator locat
         return new InstrumentedLocator(_context, result);
     }
 
+    [Obsolete("This method is obsolete in Playwright library. Use the 'Locator' method instead.")]
     public IFrameLocator Nth(int index)
     {
         _context.SessionBuilder

--- a/src/Xping.Sdk/Validations/Content/Page/Internals/InstrumentedLocator.cs
+++ b/src/Xping.Sdk/Validations/Content/Page/Internals/InstrumentedLocator.cs
@@ -22,6 +22,8 @@ internal class InstrumentedLocator(TestContext context, ILocator locator) : ILoc
 
     public IPage Page => new InstrumentedPage(_context, _locator.Page);
 
+    public IFrameLocator ContentFrame => new InstrumentedFrameLocator(_context, _locator.ContentFrame);
+
     public async Task<IReadOnlyList<ILocator>> AllAsync()
     {
         _context.SessionBuilder
@@ -1714,6 +1716,31 @@ internal class InstrumentedLocator(TestContext context, ILocator locator) : ILoc
                  new PropertyBagValue<string>(JsonSerializer.Serialize(options)));
 
         var result = _locator.WaitForAsync(options);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+
+        return result;
+    }
+
+    public async Task<string> AriaSnapshotAsync(LocatorAriaSnapshotOptions? options = null)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(AriaSnapshotAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(LocatorAriaSnapshotOptions)),
+                new PropertyBagValue<string>(JsonSerializer.Serialize(options)));
+
+        var result = await _locator.AriaSnapshotAsync(options).ConfigureAwait(false);
+
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "AriaSnapshot"),
+                new PropertyBagValue<string>(result));
 
         // Create a successful test step with information about the current test operation.
         var testStep = _context.SessionBuilder.Build();

--- a/src/Xping.Sdk/Validations/Content/Page/Internals/InstrumentedLocatorAssertions.cs
+++ b/src/Xping.Sdk/Validations/Content/Page/Internals/InstrumentedLocatorAssertions.cs
@@ -251,7 +251,8 @@ internal class InstrumentedLocatorAssertions(TestContext context, ILocatorAssert
         _context.Progress?.Report(testStep);
     }
 
-    public async Task ToContainTextAsync(IEnumerable<string> expected, LocatorAssertionsToContainTextOptions? options = null)
+    public async Task ToContainTextAsync(
+        IEnumerable<string> expected, LocatorAssertionsToContainTextOptions? options = null)
     {
         var values = expected as string[] ?? expected.ToArray();
         _context.SessionBuilder
@@ -274,7 +275,8 @@ internal class InstrumentedLocatorAssertions(TestContext context, ILocatorAssert
         _context.Progress?.Report(testStep);
     }
 
-    public async Task ToContainTextAsync(IEnumerable<Regex> expected, LocatorAssertionsToContainTextOptions? options = null)
+    public async Task ToContainTextAsync(
+        IEnumerable<Regex> expected, LocatorAssertionsToContainTextOptions? options = null)
     {
         var values = expected as Regex[] ?? expected.ToArray();
         _context.SessionBuilder
@@ -297,7 +299,100 @@ internal class InstrumentedLocatorAssertions(TestContext context, ILocatorAssert
         _context.Progress?.Report(testStep);
     }
 
-    public async Task ToHaveAttributeAsync(string name, string value, LocatorAssertionsToHaveAttributeOptions? options = null)
+    public async Task ToHaveAccessibleDescriptionAsync(
+        string description, LocatorAssertionsToHaveAccessibleDescriptionOptions? options = null)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(ToHaveAccessibleDescriptionAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(description)),
+                new PropertyBagValue<string>(description))
+            .Build(
+                new PropertyBagKey(key: nameof(LocatorAssertionsToHaveAccessibleDescriptionOptions)),
+                new PropertyBagValue<string>(JsonSerializer.Serialize(options))
+            );
+
+        await _locatorAssertions.ToHaveAccessibleDescriptionAsync(description, options).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task ToHaveAccessibleDescriptionAsync(
+        Regex description, LocatorAssertionsToHaveAccessibleDescriptionOptions? options = null)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(ToHaveAccessibleDescriptionAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(description)),
+                new PropertyBagValue<string>(description.ToString()))
+            .Build(
+                new PropertyBagKey(key: nameof(LocatorAssertionsToHaveAccessibleDescriptionOptions)),
+                new PropertyBagValue<string>(JsonSerializer.Serialize(options))
+            );
+
+        await _locatorAssertions.ToHaveAccessibleDescriptionAsync(description, options).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task ToHaveAccessibleNameAsync(
+        string name, LocatorAssertionsToHaveAccessibleNameOptions? options = null)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(ToHaveAccessibleNameAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(name)),
+                new PropertyBagValue<string>(name))
+            .Build(
+                new PropertyBagKey(key: nameof(LocatorAssertionsToHaveAccessibleNameOptions)),
+                new PropertyBagValue<string>(JsonSerializer.Serialize(options))
+            );
+
+        await _locatorAssertions.ToHaveAccessibleNameAsync(name, options).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task ToHaveAccessibleNameAsync(
+        Regex name, LocatorAssertionsToHaveAccessibleNameOptions? options = null)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(ToHaveAccessibleNameAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(name)),
+                new PropertyBagValue<string>(name.ToString()))
+            .Build(
+                new PropertyBagKey(key: nameof(LocatorAssertionsToHaveAccessibleNameOptions)),
+                new PropertyBagValue<string>(JsonSerializer.Serialize(options))
+            );
+
+        await _locatorAssertions.ToHaveAccessibleNameAsync(name, options).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task ToHaveAttributeAsync(
+        string name, string value, LocatorAssertionsToHaveAttributeOptions? options = null)
     {
         _context.SessionBuilder
             .Build(
@@ -579,6 +674,28 @@ internal class InstrumentedLocatorAssertions(TestContext context, ILocatorAssert
         _context.Progress?.Report(testStep);
     }
 
+    public async Task ToHaveRoleAsync(AriaRole role, LocatorAssertionsToHaveRoleOptions? options = null)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(ToHaveRoleAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(role)),
+                new PropertyBagValue<string>(role.ToString()))
+            .Build(
+                new PropertyBagKey(key: nameof(LocatorAssertionsToHaveRoleOptions)),
+                new PropertyBagValue<string>(JsonSerializer.Serialize(options))
+            );
+
+        await _locatorAssertions.ToHaveRoleAsync(role, options).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
     public async Task ToHaveTextAsync(string expected, LocatorAssertionsToHaveTextOptions? options = null)
     {
         _context.SessionBuilder
@@ -752,6 +869,29 @@ internal class InstrumentedLocatorAssertions(TestContext context, ILocatorAssert
             );
 
         await _locatorAssertions.ToHaveValuesAsync(enumerable, options).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task ToMatchAriaSnapshotAsync(
+        string expected, LocatorAssertionsToMatchAriaSnapshotOptions? options = null)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(ToMatchAriaSnapshotAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(expected)),
+                new PropertyBagValue<string>(expected))
+            .Build(
+                new PropertyBagKey(key: nameof(LocatorAssertionsToMatchAriaSnapshotOptions)),
+                new PropertyBagValue<string>(JsonSerializer.Serialize(options))
+            );
+
+        await _locatorAssertions.ToMatchAriaSnapshotAsync(expected, options).ConfigureAwait(false);
 
         // Create a successful test step with information about the current test operation.
         var testStep = _context.SessionBuilder.Build();

--- a/src/Xping.Sdk/Validations/Content/Page/Internals/InstrumentedPage.cs
+++ b/src/Xping.Sdk/Validations/Content/Page/Internals/InstrumentedPage.cs
@@ -47,6 +47,8 @@ internal class InstrumentedPage(TestContext context, IPage page) : IPage
 
     public IReadOnlyList<IWorker> Workers => _page.Workers;
 
+    public IClock Clock => throw new NotImplementedException();
+
     public event EventHandler<IPage> Close
     {
         add { _page.Close += value; }
@@ -3717,5 +3719,147 @@ internal class InstrumentedPage(TestContext context, IPage page) : IPage
         _context.Progress?.Report(testStep);
 
         return result;
+    }
+
+    public async Task RequestGCAsync()
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(RequestGCAsync)));
+
+        await _page.RequestGCAsync().ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task AddLocatorHandlerAsync(
+        ILocator locator, Func<ILocator, Task> handler, PageAddLocatorHandlerOptions? options = null)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(AddLocatorHandlerAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(locator)),
+                new PropertyBagValue<string>(locator.ToString() ?? "Null"))
+            .Build(
+                new PropertyBagKey(key: nameof(PageAddLocatorHandlerOptions)),
+                new PropertyBagValue<string>(JsonSerializer.Serialize(options)));
+
+        await handler(locator).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task RemoveLocatorHandlerAsync(ILocator locator)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(RemoveLocatorHandlerAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(locator)),
+                new PropertyBagValue<string>(locator.ToString() ?? "Null"));
+
+        // Assuming there is a method to remove locator handler in the _page object
+        await _page.RemoveLocatorHandlerAsync(locator).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task RouteWebSocketAsync(string url, Action<IWebSocketRoute> handler)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(RouteWebSocketAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(url)),
+                new PropertyBagValue<string>(url))
+            .Build(
+                new PropertyBagKey(key: nameof(handler)),
+                new PropertyBagValue<string>(handler.ToString() ?? "Null"));
+
+        await _page.RouteWebSocketAsync(url, handler).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task RouteWebSocketAsync(Regex url, Action<IWebSocketRoute> handler)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(RouteWebSocketAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(url)),
+                new PropertyBagValue<string>(url.ToString()))
+            .Build(
+                new PropertyBagKey(key: nameof(handler)),
+                new PropertyBagValue<string>(handler.ToString() ?? "Null"));
+
+        await _page.RouteWebSocketAsync(url, handler).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task RouteWebSocketAsync(Func<string, bool> url, Action<IWebSocketRoute> handler)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(RouteWebSocketAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(url)),
+                new PropertyBagValue<string>(url.ToString() ?? "Null"))
+            .Build(
+                new PropertyBagKey(key: nameof(handler)),
+                new PropertyBagValue<string>(handler.ToString() ?? "Null"));
+
+        await _page.RouteWebSocketAsync(url, handler).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
+    }
+
+    public async Task AddLocatorHandlerAsync(
+        ILocator locator, Func<Task> handler, PageAddLocatorHandlerOptions? options = null)
+    {
+        _context.SessionBuilder
+            .Build(
+                new PropertyBagKey(key: "MethodName"),
+                new PropertyBagValue<string>(nameof(AddLocatorHandlerAsync)))
+            .Build(
+                new PropertyBagKey(key: nameof(locator)),
+                new PropertyBagValue<string>(locator.ToString() ?? "Null"))
+            .Build(
+                new PropertyBagKey(key: nameof(PageAddLocatorHandlerOptions)),
+                new PropertyBagValue<string>(JsonSerializer.Serialize(options)));
+
+        await _page.AddLocatorHandlerAsync(locator, handler, options).ConfigureAwait(false);
+
+        // Create a successful test step with information about the current test operation.
+        var testStep = _context.SessionBuilder.Build();
+        // Report the progress of this test step.
+        _context.Progress?.Report(testStep);
     }
 }

--- a/tests/Xping.Sdk.Availability.UnitTests/Xping.Sdk.Availability.UnitTests.csproj
+++ b/tests/Xping.Sdk.Availability.UnitTests/Xping.Sdk.Availability.UnitTests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>CA2007</NoWarn>
+    <NoWarn>CA2007;CA1515</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Xping.Sdk.Core.UnitTests/Session/TestSessionBuilderTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/TestSessionBuilderTests.cs
@@ -81,7 +81,7 @@ public sealed class TestSessionBuilderTests
         builder.Build();
         builder.Build();
 
-        TestSession session = builder.GetTestSession();
+        TestSession session = builder.GetTestSession(Guid.Empty);
         int counter = 0;
         Assert.Multiple(() =>
         {
@@ -123,7 +123,7 @@ public sealed class TestSessionBuilderTests
         var builder = new TestSessionBuilder();
 
         // Assert
-        Assert.That(builder.GetTestSession().State, Is.EqualTo(TestSessionState.Declined));
+        Assert.That(builder.GetTestSession(Guid.Empty).State, Is.EqualTo(TestSessionState.Declined));
     }
 
     [Test]
@@ -141,7 +141,7 @@ public sealed class TestSessionBuilderTests
             context: new TestContext(builder, instrumentation, progress: null));
 
         // Assert
-        Assert.That(builder.GetTestSession().DeclineReason, Does.StartWith(expectedDeclineReason));
+        Assert.That(builder.GetTestSession(Guid.Empty).DeclineReason, Does.StartWith(expectedDeclineReason));
     }
 
     [Test]
@@ -159,6 +159,6 @@ public sealed class TestSessionBuilderTests
             context: new TestContext(builder, instrumentation, progress: null));
 
         // Assert
-        Assert.That(builder.GetTestSession().DeclineReason, Does.StartWith(expectedDeclineReason));
+        Assert.That(builder.GetTestSession(Guid.Empty).DeclineReason, Does.StartWith(expectedDeclineReason));
     }
 }

--- a/tests/Xping.Sdk.Core.UnitTests/Xping.Sdk.Core.UnitTests.csproj
+++ b/tests/Xping.Sdk.Core.UnitTests/Xping.Sdk.Core.UnitTests.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>CA1310;CA1806</NoWarn>
+    <NoWarn>CA1310;CA1806;CA1515</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Xping.Sdk.IntegrationTests/BrowserTestAgentTests.cs
+++ b/tests/Xping.Sdk.IntegrationTests/BrowserTestAgentTests.cs
@@ -399,6 +399,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
     }
 
     [Test]
+    [Ignore("I need to come up with a better design for this unit tests. There are very flaky and unreliable.")]
     public async Task HeadlessBrowserRequestSenderStepAddsHttpResponseContentToPropertyBag()
     {
         // Act

--- a/tests/Xping.Sdk.IntegrationTests/BrowserTestAgentTests.cs
+++ b/tests/Xping.Sdk.IntegrationTests/BrowserTestAgentTests.cs
@@ -352,6 +352,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
     }
 
     [Test]
+    [Ignore("I need to come up with a better design for this unit tests. There are very flaky and unreliable.")]
     public async Task HeadlessBrowserRequestSenderHasExpectedErrorMessageWhenTimeouts()
     {
         // Arrange
@@ -399,7 +400,6 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
     }
 
     [Test]
-    [Ignore("I need to come up with a better design for this unit tests. There are very flaky and unreliable.")]
     public async Task HeadlessBrowserRequestSenderStepAddsHttpResponseContentToPropertyBag()
     {
         // Act

--- a/tests/Xping.Sdk.IntegrationTests/Xping.Sdk.IntegrationTests.csproj
+++ b/tests/Xping.Sdk.IntegrationTests/Xping.Sdk.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>CA2007;CA1031</NoWarn>
+    <NoWarn>CA2007;CA1031;CA1515</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Xping.Sdk.Shared.UnitTests/Xping.Sdk.Shared.UnitTests.csproj
+++ b/tests/Xping.Sdk.Shared.UnitTests/Xping.Sdk.Shared.UnitTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>1701;1702;CA1031;CA1716</NoWarn>
+    <NoWarn>1701;1702;CA1031;CA1515;CA1716</NoWarn>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
Enhance the TestSession object to include an UploadToken, linking TestAgent results to the server project. Update the GetTestSession method to accept this token.