### PR TITLE
Add support for capturing and integrating test metadata in `TestSession`

### DIFF
--- a/samples/IntegrationTesting/HomePageTests.cs
+++ b/samples/IntegrationTesting/HomePageTests.cs
@@ -27,7 +27,7 @@ public class HomePageTests(TestAgent testAgent) : BaseTest(testAgent)
         TestAgent.Cleanup();
     }
 
-    [Test]
+    [Test(Description = "Ensure that the home page returns a success status code (200)")]
     public async Task EnsureSuccessHttpStatusCode()
     {
         // Arrange

--- a/src/Xping.Sdk.Core/Session/ITestSessionBuilder.cs
+++ b/src/Xping.Sdk.Core/Session/ITestSessionBuilder.cs
@@ -27,8 +27,10 @@ public interface ITestSessionBuilder
     /// <param name="uploadToken">
     /// The upload token that links the TestAgent's results to the project configured on the Xping.io server.
     /// </param>
+    /// <param name="metadata">The test metadata information.</param>
     /// <returns>The initialized test session builder.</returns>
-    ITestSessionBuilder Initiate(Uri url, DateTime startDate, TestContext context, Guid uploadToken);
+    ITestSessionBuilder Initiate(
+        Uri url, DateTime startDate, TestContext context, Guid uploadToken, TestMetadata? metadata = null);
 
     /// <summary>
     /// Gets a value indicating whether the test session is in a failed state.

--- a/src/Xping.Sdk.Core/Session/Serialization/TestSessionSerializer.cs
+++ b/src/Xping.Sdk.Core/Session/Serialization/TestSessionSerializer.cs
@@ -78,12 +78,15 @@ public sealed class TestSessionSerializer : ITestSessionSerializer
         return result as TestSession;
     }
 
-    private static List<Type> GetKnownTypes() => [
+    private static List<Type> GetKnownTypes() =>
+    [
         typeof(TestStep[]),
-            typeof(PropertyBag<IPropertyBagValue>),
-            typeof(Dictionary<PropertyBagKey, IPropertyBagValue>),
-            typeof(PropertyBagValue<byte[]>),
-            typeof(PropertyBagValue<string>),
-            typeof(PropertyBagValue<string[]>),
-            typeof(PropertyBagValue<Dictionary<string, string>>)];
+        typeof(TestMetadata),
+        typeof(PropertyBag<IPropertyBagValue>),
+        typeof(Dictionary<PropertyBagKey, IPropertyBagValue>),
+        typeof(PropertyBagValue<byte[]>),
+        typeof(PropertyBagValue<string>),
+        typeof(PropertyBagValue<string[]>),
+        typeof(PropertyBagValue<Dictionary<string, string>>)
+    ];
 }

--- a/src/Xping.Sdk.Core/Session/TestMetadata.cs
+++ b/src/Xping.Sdk.Core/Session/TestMetadata.cs
@@ -1,0 +1,228 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * This file is part of the Xping SDK.
+ *
+ * License: [MIT]
+ */
+
+using System.Diagnostics;
+using System.Runtime.Serialization;
+
+namespace Xping.Sdk.Core.Session;
+
+/// <summary>
+/// Represents metadata information for a test method and its containing class.
+/// Contains information about method names, class details, and their attributes.
+/// </summary>
+[Serializable]
+[DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
+public sealed class TestMetadata : ISerializable, IDeserializationCallback, IEquatable<TestMetadata>
+{
+    /// <summary>
+    /// Gets or sets the name of the test method.
+    /// </summary>
+    public string MethodName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the class containing the test method.
+    /// </summary>
+    public string ClassName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the namespace of the class containing the test method.
+    /// </summary>
+    public string Namespace { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the process executing the test.
+    /// <para>
+    /// Note: On macOS and Linux, this value may be truncated to the first 15 characters due to 
+    /// OS-level limitations in the process table.
+    /// </para>
+    /// </summary>
+    public string ProcessName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the process ID of the executing process.
+    /// </summary>
+    public int ProcessId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the list of attribute names applied to the class.
+    /// Note: Stores attribute names instead of Attribute objects for serialization compatibility.
+    /// </summary>
+    public IReadOnlyCollection<string> ClassAttributeNames { get; init; } = [];
+
+    /// <summary>
+    /// Gets or sets the list of attribute names applied to the test method.
+    /// Note: Stores attribute names instead of Attribute objects for serialization compatibility.
+    /// </summary>
+    public IReadOnlyCollection<string> MethodAttributeNames { get; init; } = [];
+
+    /// <summary>
+    /// Gets or sets the test description extracted from test attributes.
+    /// This is stored directly to avoid reflection during deserialization.
+    /// </summary>
+    public string? TestDescription { get; init; }
+
+    /// <summary>
+    /// Gets the full qualified name of the test method including namespace and class name.
+    /// </summary>
+    public string FullyQualifiedName => $"{Namespace}.{ClassName}.{MethodName}";
+
+    /// <summary>
+    /// Gets the display name for the test, preferring the description if available.
+    /// </summary>
+    public string DisplayName => !string.IsNullOrEmpty(TestDescription) ? TestDescription : MethodName;
+
+    /// <summary>
+    /// Gets a value indicating whether this metadata represents a test method (as opposed to a process fallback).
+    /// </summary>
+    public bool IsTestMethod => !string.IsNullOrEmpty(MethodName) &&
+                                !string.IsNullOrEmpty(ClassName) &&
+                                !string.IsNullOrEmpty(Namespace) &&
+                                MethodAttributeNames.Count != 0;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestMetadata"/> class.
+    /// </summary>
+    public TestMetadata()
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestMetadata"/> class with serialized data.
+    /// </summary>
+    /// <param name="info">The serialization info.</param>
+    /// <param name="context">The streaming context.</param>
+    public TestMetadata(SerializationInfo info, StreamingContext context)
+    {
+        ArgumentNullException.ThrowIfNull(info, nameof(info));
+
+        MethodName = info.GetString(nameof(MethodName)) ?? string.Empty;
+        ClassName = info.GetString(nameof(ClassName)) ?? string.Empty;
+        Namespace = info.GetString(nameof(Namespace)) ?? string.Empty;
+        ProcessName = info.GetString(nameof(ProcessName)) ?? string.Empty;
+        ProcessId = info.GetInt32(nameof(ProcessId));
+        ClassAttributeNames =
+            (info.GetValue(nameof(ClassAttributeNames), typeof(string[])) as string[])?.ToList() ?? [];
+        MethodAttributeNames =
+            (info.GetValue(nameof(MethodAttributeNames), typeof(string[])) as string[])?.ToList() ?? [];
+        TestDescription = info.GetString(nameof(TestDescription));
+    }
+
+    /// <summary>
+    /// Checks if a specific attribute type name exists either on the method or the class level.
+    /// </summary>
+    /// <param name="attributeName">The name of the attribute to check for (e.g., "TestAttribute").</param>
+    /// <returns>True if the attribute exists on either the method or class level; otherwise, false.</returns>
+    public bool HasAttribute(string attributeName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(attributeName);
+
+        return MethodAttributeNames.Any(name => name.Contains(attributeName, StringComparison.OrdinalIgnoreCase)) ||
+               ClassAttributeNames.Any(name => name.Contains(attributeName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Checks if a test attribute exists on the method level.
+    /// </summary>
+    /// <returns>True if a test attribute exists; otherwise, false.</returns>
+    public bool HasTestAttribute()
+    {
+        return MethodAttributeNames.Any(name =>
+            name.Contains("Test", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("Fact", StringComparison.OrdinalIgnoreCase) ||
+            name.Contains("Theory", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Returns a string representation of the test metadata.
+    /// </summary>
+    /// <returns>A formatted string containing the test information.</returns>
+    public override string ToString()
+    {
+        if (IsTestMethod)
+        {
+            var description = !string.IsNullOrEmpty(TestDescription) ? $" - {TestDescription}" : "";
+            return $"{FullyQualifiedName}{description} [{ProcessName}:{ProcessId}]";
+        }
+
+        return $"Process: {ProcessName} (ID: {ProcessId})";
+    }
+
+    /// <summary>
+    /// Determines whether the specified object is equal to the current object.
+    /// </summary>
+    /// <param name="obj">The object to compare with the current object.</param>
+    /// <returns>True if the specified object is equal to the current object; otherwise, false.</returns>
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as TestMetadata);
+    }
+
+    /// <summary>
+    /// Indicates whether the current object is equal to another object of the same type.
+    /// </summary>
+    /// <param name="other">An object to compare with this object.</param>
+    /// <returns>True if the current object is equal to the other parameter; otherwise, false.</returns>
+    public bool Equals(TestMetadata? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+
+        return MethodName == other.MethodName &&
+               ClassName == other.ClassName &&
+               Namespace == other.Namespace &&
+               ProcessName == other.ProcessName &&
+               ProcessId == other.ProcessId;
+    }
+
+    /// <summary>
+    /// Returns the hash code for this instance.
+    /// </summary>
+    /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(MethodName, ClassName, Namespace, ProcessName, ProcessId);
+    }
+
+    /// <summary>
+    /// Equality operator.
+    /// </summary>
+    public static bool operator ==(TestMetadata? left, TestMetadata? right)
+    {
+        return Equals(left, right);
+    }
+
+    /// <summary>
+    /// Inequality operator.
+    /// </summary>
+    public static bool operator !=(TestMetadata? left, TestMetadata? right)
+    {
+        return !Equals(left, right);
+    }
+
+    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        info.AddValue(nameof(MethodName), MethodName);
+        info.AddValue(nameof(ClassName), ClassName);
+        info.AddValue(nameof(Namespace), Namespace);
+        info.AddValue(nameof(ProcessName), ProcessName);
+        info.AddValue(nameof(ProcessId), ProcessId);
+        info.AddValue(nameof(ClassAttributeNames), ClassAttributeNames.ToArray());
+        info.AddValue(nameof(MethodAttributeNames), MethodAttributeNames.ToArray());
+        info.AddValue(nameof(TestDescription), TestDescription);
+    }
+
+    void IDeserializationCallback.OnDeserialization(object? sender)
+    {
+        // Validation after deserialization if needed
+    }
+
+    private string GetDebuggerDisplay()
+    {
+        return IsTestMethod
+            ? $"{FullyQualifiedName} [{ProcessName}:{ProcessId}]"
+            : $"Process: {ProcessName} (ID: {ProcessId})";
+    }
+}

--- a/src/Xping.Sdk.Core/Session/TestSessionBuilder.cs
+++ b/src/Xping.Sdk.Core/Session/TestSessionBuilder.cs
@@ -27,6 +27,7 @@ public class TestSessionBuilder : ITestSessionBuilder
     private TestContext? _context;
     private Error? _error;
     private PropertyBag<IPropertyBagValue>? _propertyBag;
+    private TestMetadata? _metadata;
 
     /// <summary>
     /// Gets a value indicating whether the test session has failed.
@@ -58,15 +59,18 @@ public class TestSessionBuilder : ITestSessionBuilder
     /// <param name="startDate">The start date of the test session.</param>
     /// <param name="context">The context responsible for maintaining the state of the test execution.</param>
     /// <param name="uploadToken">
-    /// The upload token that links the TestAgent's results to the project configured on the server.
+    ///     The upload token that links the TestAgent's results to the project configured on the server.
     /// </param>
+    /// <param name="metadata">The test metadata information.</param>
     /// <returns>The initialized test session builder.</returns>
-    public ITestSessionBuilder Initiate(Uri url, DateTime startDate, TestContext context, Guid uploadToken)
+    public ITestSessionBuilder Initiate(
+        Uri url, DateTime startDate, TestContext context, Guid uploadToken, TestMetadata? metadata = null)
     {
-        _url = url;
+        _url = url.RequireNotNull(nameof(url));
+        _context = context.RequireNotNull(nameof(context));
         _startDate = startDate;
         _uploadToken = uploadToken;
-        _context = context.RequireNotNull(nameof(context));
+        _metadata = metadata;
 
         // Reset internal state.
         _error = null;
@@ -241,7 +245,8 @@ public class TestSessionBuilder : ITestSessionBuilder
                 // Set the test session status to completed to indicate that no further modifications are allowed.
                 State = TestSessionState.Completed,
                 DeclineReason = null,
-                UploadToken = _uploadToken
+                UploadToken = _uploadToken,
+                Metadata = _metadata,
             };
 
             return session;
@@ -255,7 +260,8 @@ public class TestSessionBuilder : ITestSessionBuilder
                 Steps = _steps,
                 State = TestSessionState.Declined,
                 DeclineReason = ex.Message,
-                UploadToken = _uploadToken
+                UploadToken = _uploadToken,
+                Metadata = _metadata
             };
 
             return session;

--- a/src/Xping.Sdk.Core/Session/TestSessionBuilder.cs
+++ b/src/Xping.Sdk.Core/Session/TestSessionBuilder.cs
@@ -66,9 +66,9 @@ public class TestSessionBuilder : ITestSessionBuilder
     public ITestSessionBuilder Initiate(
         Uri url, DateTime startDate, TestContext context, Guid uploadToken, TestMetadata? metadata = null)
     {
-        _url = url.RequireNotNull(nameof(url));
-        _context = context.RequireNotNull(nameof(context));
+        _url = url;
         _startDate = startDate;
+        _context = context.RequireNotNull(nameof(context));
         _uploadToken = uploadToken;
         _metadata = metadata;
 

--- a/tests/Xping.Sdk.Availability.UnitTests/Helpers/HtmlContentTestsHelpers.cs
+++ b/tests/Xping.Sdk.Availability.UnitTests/Helpers/HtmlContentTestsHelpers.cs
@@ -178,7 +178,8 @@ internal static class HtmlContentTestsHelpers
                 It.IsAny<Uri>(),
                 It.IsAny<DateTime>(),
                 It.IsAny<TestContext>(),
-                Guid.Empty))
+                Guid.Empty,
+                new TestMetadata()))
             .Returns(sessionBuilder);
     }
 }

--- a/tests/Xping.Sdk.Core.UnitTests/Session/TestMetadataTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/TestMetadataTests.cs
@@ -1,0 +1,610 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * This file is part of the Xping SDK.
+ *
+ * License: [MIT]
+ */
+
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xping.Sdk.Core.Session;
+
+namespace Xping.Sdk.UnitTests.Session;
+
+[TestFixture]
+public sealed class TestMetadataTests
+{
+    private static TestMetadata CreateTestMetadataUnderTest(
+        string methodName = "TestMethod",
+        string className = "TestClass",
+        string namespaceName = "TestNamespace",
+        string processName = "testprocess",
+        int processId = 1234,
+        IReadOnlyCollection<string>? classAttributeNames = null,
+        IReadOnlyCollection<string>? methodAttributeNames = null,
+        string? testDescription = null)
+    {
+        return new TestMetadata
+        {
+            MethodName = methodName,
+            ClassName = className,
+            Namespace = namespaceName,
+            ProcessName = processName,
+            ProcessId = processId,
+            ClassAttributeNames = classAttributeNames ?? ["TestFixtureAttribute"],
+            MethodAttributeNames = methodAttributeNames ?? ["TestAttribute"],
+            TestDescription = testDescription
+        };
+    }
+
+    [Test]
+    public void Constructor_DefaultConstructor_InitializesWithEmptyValues()
+    {
+        // Act
+        var metadata = new TestMetadata();
+
+        // Assert
+        Assert.That(metadata.MethodName, Is.EqualTo(string.Empty));
+        Assert.That(metadata.ClassName, Is.EqualTo(string.Empty));
+        Assert.That(metadata.Namespace, Is.EqualTo(string.Empty));
+        Assert.That(metadata.ProcessName, Is.EqualTo(string.Empty));
+        Assert.That(metadata.ProcessId, Is.EqualTo(0));
+        Assert.That(metadata.ClassAttributeNames, Is.Empty);
+        Assert.That(metadata.MethodAttributeNames, Is.Empty);
+        Assert.That(metadata.TestDescription, Is.Null);
+    }
+
+    [Test]
+    public void FullyQualifiedName_WithValidNamespaceClassAndMethod_ReturnsCorrectFormat()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodName: "MyTestMethod",
+            className: "MyTestClass",
+            namespaceName: "MyTestNamespace");
+
+        // Act
+        var fullyQualifiedName = metadata.FullyQualifiedName;
+
+        // Assert
+        Assert.That(fullyQualifiedName, Is.EqualTo("MyTestNamespace.MyTestClass.MyTestMethod"));
+    }
+
+    [Test]
+    public void DisplayName_WithTestDescription_ReturnsDescription()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            testDescription: "This is a test description");
+
+        // Act
+        var displayName = metadata.DisplayName;
+
+        // Assert
+        Assert.That(displayName, Is.EqualTo("This is a test description"));
+    }
+
+    [Test]
+    public void DisplayName_WithoutTestDescription_ReturnsMethodName()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            testDescription: null);
+
+        // Act
+        var displayName = metadata.DisplayName;
+
+        // Assert
+        Assert.That(displayName, Is.EqualTo("TestMethod"));
+    }
+
+    [Test]
+    public void DisplayName_WithEmptyTestDescription_ReturnsMethodName()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            testDescription: string.Empty);
+
+        // Act
+        var displayName = metadata.DisplayName;
+
+        // Assert
+        Assert.That(displayName, Is.EqualTo("TestMethod"));
+    }
+
+    [Test]
+    public void IsTestMethod_WithValidTestData_ReturnsTrue()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest();
+
+        // Act
+        var isTestMethod = metadata.IsTestMethod;
+
+        // Assert
+        Assert.That(isTestMethod, Is.True);
+    }
+
+    [Test]
+    public void IsTestMethod_WithEmptyMethodName_ReturnsFalse()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(methodName: string.Empty);
+
+        // Act
+        var isTestMethod = metadata.IsTestMethod;
+
+        // Assert
+        Assert.That(isTestMethod, Is.False);
+    }
+
+    [Test]
+    public void IsTestMethod_WithEmptyClassName_ReturnsFalse()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(className: string.Empty);
+
+        // Act
+        var isTestMethod = metadata.IsTestMethod;
+
+        // Assert
+        Assert.That(isTestMethod, Is.False);
+    }
+
+    [Test]
+    public void IsTestMethod_WithEmptyNamespace_ReturnsFalse()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(namespaceName: string.Empty);
+
+        // Act
+        var isTestMethod = metadata.IsTestMethod;
+
+        // Assert
+        Assert.That(isTestMethod, Is.False);
+    }
+
+    [Test]
+    public void IsTestMethod_WithEmptyMethodAttributes_ReturnsFalse()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(methodAttributeNames: []);
+
+        // Act
+        var isTestMethod = metadata.IsTestMethod;
+
+        // Assert
+        Assert.That(isTestMethod, Is.False);
+    }
+
+    [Test]
+    public void HasAttribute_WithExistingMethodAttribute_ReturnsTrue()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodAttributeNames: ["TestAttribute", "CategoryAttribute"]);
+
+        // Act & Assert
+        Assert.That(metadata.HasAttribute("TestAttribute"), Is.True);
+        Assert.That(metadata.HasAttribute("CategoryAttribute"), Is.True);
+    }
+
+    [Test]
+    public void HasAttribute_WithExistingClassAttribute_ReturnsTrue()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            classAttributeNames: ["TestFixtureAttribute", "CategoryAttribute"]);
+
+        // Act & Assert
+        Assert.That(metadata.HasAttribute("TestFixtureAttribute"), Is.True);
+        Assert.That(metadata.HasAttribute("CategoryAttribute"), Is.True);
+    }
+
+    [Test]
+    public void HasAttribute_WithNonExistingAttribute_ReturnsFalse()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodAttributeNames: ["TestAttribute"],
+            classAttributeNames: ["TestFixtureAttribute"]);
+
+        // Act & Assert
+        Assert.That(metadata.HasAttribute("NonExistingAttribute"), Is.False);
+    }
+
+    [Test]
+    public void HasAttribute_WithPartialAttributeName_ReturnsTrue()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodAttributeNames: ["TestAttribute"]);
+
+        // Act & Assert
+        Assert.That(metadata.HasAttribute("Test"), Is.True);
+    }
+
+    [Test]
+    public void HasAttribute_WithCaseInsensitiveMatch_ReturnsTrue()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodAttributeNames: ["TestAttribute"]);
+
+        // Act & Assert
+        Assert.That(metadata.HasAttribute("testattribute"), Is.True);
+        Assert.That(metadata.HasAttribute("TESTATTRIBUTE"), Is.True);
+    }
+
+    [Test]
+    public void HasAttribute_WithNullOrWhitespaceAttributeName_ThrowsArgumentException()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest();
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => metadata.HasAttribute(null!));
+        Assert.Throws<ArgumentException>(() => metadata.HasAttribute(string.Empty));
+        Assert.Throws<ArgumentException>(() => metadata.HasAttribute("   "));
+    }
+
+    [Test]
+    public void HasTestAttribute_WithTestAttribute_ReturnsTrue()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodAttributeNames: ["TestAttribute"]);
+
+        // Act & Assert
+        Assert.That(metadata.HasTestAttribute(), Is.True);
+    }
+
+    [Test]
+    public void HasTestAttribute_WithFactAttribute_ReturnsTrue()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodAttributeNames: ["FactAttribute"]);
+
+        // Act & Assert
+        Assert.That(metadata.HasTestAttribute(), Is.True);
+    }
+
+    [Test]
+    public void HasTestAttribute_WithTheoryAttribute_ReturnsTrue()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodAttributeNames: ["TheoryAttribute"]);
+
+        // Act & Assert
+        Assert.That(metadata.HasTestAttribute(), Is.True);
+    }
+
+    [Test]
+    public void HasTestAttribute_WithNonTestAttribute_ReturnsFalse()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodAttributeNames: ["CategoryAttribute", "ObsoleteAttribute"]);
+
+        // Act & Assert
+        Assert.That(metadata.HasTestAttribute(), Is.False);
+    }
+
+    [Test]
+    public void ToString_ForTestMethod_ReturnsFormattedString()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234);
+
+        // Act
+        var result = metadata.ToString();
+
+        // Assert
+        Assert.That(result, Is.EqualTo("TestNamespace.TestClass.TestMethod [testprocess:1234]"));
+    }
+
+    [Test]
+    public void ToString_ForTestMethodWithDescription_ReturnsFormattedStringWithDescription()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234,
+            testDescription: "Test Description");
+
+        // Act
+        var result = metadata.ToString();
+
+        // Assert
+        Assert.That(result, Is.EqualTo("TestNamespace.TestClass.TestMethod - Test Description [testprocess:1234]"));
+    }
+
+    [Test]
+    public void ToString_ForNonTestMethod_ReturnsProcessInfo()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodName: string.Empty,
+            className: string.Empty,
+            namespaceName: string.Empty,
+            processName: "testprocess",
+            processId: 1234,
+            methodAttributeNames: []);
+
+        // Act
+        var result = metadata.ToString();
+
+        // Assert
+        Assert.That(result, Is.EqualTo("Process: testprocess (ID: 1234)"));
+    }
+
+    [Test]
+    public void Equals_WithSameValues_ReturnsTrue()
+    {
+        // Arrange
+        var metadata1 = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234);
+
+        var metadata2 = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234);
+
+        // Act & Assert
+        Assert.That(metadata1.Equals(metadata2), Is.True);
+        Assert.That(metadata1 == metadata2, Is.True);
+        Assert.That(metadata1 != metadata2, Is.False);
+    }
+
+    [Test]
+    public void Equals_WithDifferentValues_ReturnsFalse()
+    {
+        // Arrange
+        var metadata1 = CreateTestMetadataUnderTest(
+            methodName: "TestMethod1",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234);
+
+        var metadata2 = CreateTestMetadataUnderTest(
+            methodName: "TestMethod2",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234);
+
+        // Act & Assert
+        Assert.That(metadata1.Equals(metadata2), Is.False);
+        Assert.That(metadata1 == metadata2, Is.False);
+        Assert.That(metadata1 != metadata2, Is.True);
+    }
+
+    [Test]
+    public void Equals_WithNull_ReturnsFalse()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest();
+
+        // Act & Assert
+        Assert.That(metadata.Equals(null), Is.False);
+        Assert.That(metadata == null, Is.False);
+        Assert.That(metadata != null, Is.True);
+    }
+
+    [Test]
+    public void Equals_WithSameReference_ReturnsTrue()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest();
+
+        // Act & Assert
+        Assert.That(metadata.Equals(metadata), Is.True);
+        Assert.That(metadata == metadata, Is.True);
+        Assert.That(metadata != metadata, Is.False);
+    }
+
+    [Test]
+    public void GetHashCode_WithSameValues_ReturnsSameHashCode()
+    {
+        // Arrange
+        var metadata1 = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234);
+
+        var metadata2 = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234);
+
+        // Act & Assert
+        Assert.That(metadata1.GetHashCode(), Is.EqualTo(metadata2.GetHashCode()));
+    }
+
+    [Test]
+    public void GetHashCode_WithDifferentValues_ReturnsDifferentHashCode()
+    {
+        // Arrange
+        var metadata1 = CreateTestMetadataUnderTest(
+            methodName: "TestMethod1",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234);
+
+        var metadata2 = CreateTestMetadataUnderTest(
+            methodName: "TestMethod2",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234);
+
+        // Act & Assert
+        Assert.That(metadata1.GetHashCode(), Is.Not.EqualTo(metadata2.GetHashCode()));
+    }
+
+    [Test]
+    public void Serialization_RoundTrip_PreservesAllData()
+    {
+        // Arrange
+        var original = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234,
+            classAttributeNames: ["TestFixtureAttribute", "CategoryAttribute"],
+            methodAttributeNames: ["TestAttribute", "DescriptionAttribute"],
+            testDescription: "Test Description");
+
+        // Act
+        var serialized = SerializeToMemoryStream(original);
+        var deserialized = DeserializeFromMemoryStream<TestMetadata>(serialized);
+
+        // Assert
+        Assert.That(deserialized.MethodName, Is.EqualTo(original.MethodName));
+        Assert.That(deserialized.ClassName, Is.EqualTo(original.ClassName));
+        Assert.That(deserialized.Namespace, Is.EqualTo(original.Namespace));
+        Assert.That(deserialized.ProcessName, Is.EqualTo(original.ProcessName));
+        Assert.That(deserialized.ProcessId, Is.EqualTo(original.ProcessId));
+        Assert.That(deserialized.ClassAttributeNames, Is.EquivalentTo(original.ClassAttributeNames));
+        Assert.That(deserialized.MethodAttributeNames, Is.EquivalentTo(original.MethodAttributeNames));
+        Assert.That(deserialized.TestDescription, Is.EqualTo(original.TestDescription));
+    }
+
+    [Test]
+    public void Serialization_WithNullValues_HandlesNullsCorrectly()
+    {
+        // Arrange
+        var original = new TestMetadata
+        {
+            MethodName = "TestMethod",
+            ClassName = "TestClass",
+            Namespace = "TestNamespace",
+            ProcessName = "testprocess",
+            ProcessId = 1234,
+            ClassAttributeNames = ["TestFixtureAttribute"],
+            MethodAttributeNames = ["TestAttribute"],
+            TestDescription = null
+        };
+
+        // Act
+        var serialized = SerializeToMemoryStream(original);
+        var deserialized = DeserializeFromMemoryStream<TestMetadata>(serialized);
+
+        // Assert
+        Assert.That(deserialized.TestDescription, Is.Null);
+        Assert.That(deserialized.MethodName, Is.EqualTo(original.MethodName));
+    }
+
+    [Test]
+    public void SerializationConstructor_WithNullSerializationInfo_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => 
+            new TestMetadata(null!, new StreamingContext()));
+    }
+
+    [Test]
+    public void DebuggerDisplay_ForTestMethod_ReturnsCorrectFormat()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodName: "TestMethod",
+            className: "TestClass",
+            namespaceName: "TestNamespace",
+            processName: "testprocess",
+            processId: 1234);
+
+        // Act
+        var debugDisplay = metadata.ToString(); // DebuggerDisplay uses the same logic as ToString
+
+        // Assert
+        Assert.That(debugDisplay, Is.EqualTo("TestNamespace.TestClass.TestMethod [testprocess:1234]"));
+    }
+
+    [Test]
+    public void DebuggerDisplay_ForNonTestMethod_ReturnsProcessInfo()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            methodName: string.Empty,
+            className: string.Empty,
+            namespaceName: string.Empty,
+            processName: "testprocess",
+            processId: 1234,
+            methodAttributeNames: []);
+
+        // Act
+        var debugDisplay = metadata.ToString(); // DebuggerDisplay uses the same logic as ToString
+
+        // Assert
+        Assert.That(debugDisplay, Is.EqualTo("Process: testprocess (ID: 1234)"));
+    }
+
+    [Test]
+    public void Properties_WithInitValues_AreSetCorrectly()
+    {
+        // Arrange & Act
+        var metadata = new TestMetadata
+        {
+            MethodName = "TestMethod",
+            ClassName = "TestClass",
+            Namespace = "TestNamespace",
+            ProcessName = "testprocess",
+            ProcessId = 1234,
+            ClassAttributeNames = ["TestFixtureAttribute"],
+            MethodAttributeNames = ["TestAttribute"],
+            TestDescription = "Test Description"
+        };
+
+        // Assert
+        Assert.That(metadata.MethodName, Is.EqualTo("TestMethod"));
+        Assert.That(metadata.ClassName, Is.EqualTo("TestClass"));
+        Assert.That(metadata.Namespace, Is.EqualTo("TestNamespace"));
+        Assert.That(metadata.ProcessName, Is.EqualTo("testprocess"));
+        Assert.That(metadata.ProcessId, Is.EqualTo(1234));
+        Assert.That(metadata.ClassAttributeNames, Is.EquivalentTo(new[] { "TestFixtureAttribute" }));
+        Assert.That(metadata.MethodAttributeNames, Is.EquivalentTo(new[] { "TestAttribute" }));
+        Assert.That(metadata.TestDescription, Is.EqualTo("Test Description"));
+    }
+
+    private static byte[] SerializeToMemoryStream<T>(T obj) where T : ISerializable
+    {
+        using var memoryStream = new MemoryStream();
+        var formatter = new BinaryFormatter();
+        formatter.Serialize(memoryStream, obj);
+        return memoryStream.ToArray();
+    }
+
+    private static T DeserializeFromMemoryStream<T>(byte[] data)
+    {
+        using var memoryStream = new MemoryStream(data);
+        var formatter = new BinaryFormatter();
+        return (T)formatter.Deserialize(memoryStream);
+    }
+}

--- a/tests/Xping.Sdk.Core.UnitTests/Session/TestMetadataTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/TestMetadataTests.cs
@@ -18,7 +18,7 @@ public sealed class TestMetadataTests
         string methodName = "TestMethod",
         string className = "TestClass",
         string namespaceName = "TestNamespace",
-        string processName = "testprocess",
+        string processName = "TestProcess",
         int processId = 1234,
         IReadOnlyCollection<string>? classAttributeNames = null,
         IReadOnlyCollection<string>? methodAttributeNames = null,
@@ -38,7 +38,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void Constructor_DefaultConstructor_InitializesWithEmptyValues()
+    public void ConstructorDefaultConstructorInitializesWithEmptyValues()
     {
         // Act
         var metadata = new TestMetadata();
@@ -55,7 +55,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void FullyQualifiedName_WithValidNamespaceClassAndMethod_ReturnsCorrectFormat()
+    public void FullyQualifiedNameWithValidNamespaceClassAndMethodReturnsCorrectFormat()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -71,7 +71,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void DisplayName_WithTestDescription_ReturnsDescription()
+    public void DisplayNameWithTestDescriptionReturnsDescription()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -86,7 +86,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void DisplayName_WithoutTestDescription_ReturnsMethodName()
+    public void DisplayNameWithoutTestDescriptionReturnsMethodName()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -101,7 +101,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void DisplayName_WithEmptyTestDescription_ReturnsMethodName()
+    public void DisplayNameWithEmptyTestDescriptionReturnsMethodName()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -116,7 +116,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void IsTestMethod_WithValidTestData_ReturnsTrue()
+    public void IsTestMethodWithValidTestDataReturnsTrue()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest();
@@ -129,7 +129,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void IsTestMethod_WithEmptyMethodName_ReturnsFalse()
+    public void IsTestMethodWithEmptyMethodNameReturnsFalse()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(methodName: string.Empty);
@@ -142,7 +142,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void IsTestMethod_WithEmptyClassName_ReturnsFalse()
+    public void IsTestMethodWithEmptyClassNameReturnsFalse()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(className: string.Empty);
@@ -155,7 +155,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void IsTestMethod_WithEmptyNamespace_ReturnsFalse()
+    public void IsTestMethodWithEmptyNamespaceReturnsFalse()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(namespaceName: string.Empty);
@@ -168,7 +168,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void IsTestMethod_WithEmptyMethodAttributes_ReturnsFalse()
+    public void IsTestMethodWithEmptyMethodAttributesReturnsFalse()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(methodAttributeNames: []);
@@ -181,7 +181,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void HasAttribute_WithExistingMethodAttribute_ReturnsTrue()
+    public void HasAttributeWithExistingMethodAttributeReturnsTrue()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -193,7 +193,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void HasAttribute_WithExistingClassAttribute_ReturnsTrue()
+    public void HasAttributeWithExistingClassAttributeReturnsTrue()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -205,7 +205,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void HasAttribute_WithNonExistingAttribute_ReturnsFalse()
+    public void HasAttributeWithNonExistingAttributeReturnsFalse()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -217,7 +217,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void HasAttribute_WithPartialAttributeName_ReturnsTrue()
+    public void HasAttributeWithPartialAttributeNameReturnsTrue()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -228,7 +228,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void HasAttribute_WithCaseInsensitiveMatch_ReturnsTrue()
+    public void HasAttributeWithCaseInsensitiveMatchReturnsTrue()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -240,19 +240,19 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void HasAttribute_WithNullOrWhitespaceAttributeName_ThrowsArgumentException()
+    public void HasAttributeWithNullOrWhitespaceAttributeNameThrowsArgumentException()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest();
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => metadata.HasAttribute(null!));
+        Assert.Throws<ArgumentNullException>(() => metadata.HasAttribute(null!));
         Assert.Throws<ArgumentException>(() => metadata.HasAttribute(string.Empty));
         Assert.Throws<ArgumentException>(() => metadata.HasAttribute("   "));
     }
 
     [Test]
-    public void HasTestAttribute_WithTestAttribute_ReturnsTrue()
+    public void HasTestAttributeWithTestAttributeReturnsTrue()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -263,7 +263,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void HasTestAttribute_WithFactAttribute_ReturnsTrue()
+    public void HasTestAttributeWithFactAttributeReturnsTrue()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -274,7 +274,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void HasTestAttribute_WithTheoryAttribute_ReturnsTrue()
+    public void HasTestAttributeWithTheoryAttributeReturnsTrue()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -285,7 +285,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void HasTestAttribute_WithNonTestAttribute_ReturnsFalse()
+    public void HasTestAttributeWithNonTestAttributeReturnsFalse()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
@@ -296,32 +296,32 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void ToString_ForTestMethod_ReturnsFormattedString()
+    public void ToStringForTestMethodReturnsFormattedString()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
             methodName: "TestMethod",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234);
 
         // Act
         var result = metadata.ToString();
 
         // Assert
-        Assert.That(result, Is.EqualTo("TestNamespace.TestClass.TestMethod [testprocess:1234]"));
+        Assert.That(result, Is.EqualTo("TestNamespace.TestClass.TestMethod [TestProcess:1234]"));
     }
 
     [Test]
-    public void ToString_ForTestMethodWithDescription_ReturnsFormattedStringWithDescription()
+    public void ToStringForTestMethodWithDescriptionReturnsFormattedStringWithDescription()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
             methodName: "TestMethod",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234,
             testDescription: "Test Description");
 
@@ -329,18 +329,18 @@ public sealed class TestMetadataTests
         var result = metadata.ToString();
 
         // Assert
-        Assert.That(result, Is.EqualTo("TestNamespace.TestClass.TestMethod - Test Description [testprocess:1234]"));
+        Assert.That(result, Is.EqualTo("TestNamespace.TestClass.TestMethod - Test Description [TestProcess:1234]"));
     }
 
     [Test]
-    public void ToString_ForNonTestMethod_ReturnsProcessInfo()
+    public void ToStringForNonTestMethodReturnsProcessInfo()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
             methodName: string.Empty,
             className: string.Empty,
             namespaceName: string.Empty,
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234,
             methodAttributeNames: []);
 
@@ -348,25 +348,25 @@ public sealed class TestMetadataTests
         var result = metadata.ToString();
 
         // Assert
-        Assert.That(result, Is.EqualTo("Process: testprocess (ID: 1234)"));
+        Assert.That(result, Is.EqualTo("Process: TestProcess (ID: 1234)"));
     }
 
     [Test]
-    public void Equals_WithSameValues_ReturnsTrue()
+    public void EqualsWithSameValuesReturnsTrue()
     {
         // Arrange
         var metadata1 = CreateTestMetadataUnderTest(
             methodName: "TestMethod",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234);
 
         var metadata2 = CreateTestMetadataUnderTest(
             methodName: "TestMethod",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234);
 
         // Act & Assert
@@ -376,21 +376,21 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void Equals_WithDifferentValues_ReturnsFalse()
+    public void EqualsWithDifferentValuesReturnsFalse()
     {
         // Arrange
         var metadata1 = CreateTestMetadataUnderTest(
             methodName: "TestMethod1",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234);
 
         var metadata2 = CreateTestMetadataUnderTest(
             methodName: "TestMethod2",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234);
 
         // Act & Assert
@@ -400,7 +400,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void Equals_WithNull_ReturnsFalse()
+    public void EqualsWithNullReturnsFalse()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest();
@@ -412,33 +412,21 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void Equals_WithSameReference_ReturnsTrue()
-    {
-        // Arrange
-        var metadata = CreateTestMetadataUnderTest();
-
-        // Act & Assert
-        Assert.That(metadata.Equals(metadata), Is.True);
-        Assert.That(metadata == metadata, Is.True);
-        Assert.That(metadata != metadata, Is.False);
-    }
-
-    [Test]
-    public void GetHashCode_WithSameValues_ReturnsSameHashCode()
+    public void GetHashCodeWithSameValuesReturnsSameHashCode()
     {
         // Arrange
         var metadata1 = CreateTestMetadataUnderTest(
             methodName: "TestMethod",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234);
 
         var metadata2 = CreateTestMetadataUnderTest(
             methodName: "TestMethod",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234);
 
         // Act & Assert
@@ -446,21 +434,21 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void GetHashCode_WithDifferentValues_ReturnsDifferentHashCode()
+    public void GetHashCodeWithDifferentValuesReturnsDifferentHashCode()
     {
         // Arrange
         var metadata1 = CreateTestMetadataUnderTest(
             methodName: "TestMethod1",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234);
 
         var metadata2 = CreateTestMetadataUnderTest(
             methodName: "TestMethod2",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234);
 
         // Act & Assert
@@ -468,14 +456,14 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void Serialization_RoundTrip_PreservesAllData()
+    public void SerializationRoundTripPreservesAllData()
     {
         // Arrange
         var original = CreateTestMetadataUnderTest(
             methodName: "TestMethod",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234,
             classAttributeNames: ["TestFixtureAttribute", "CategoryAttribute"],
             methodAttributeNames: ["TestAttribute", "DescriptionAttribute"],
@@ -497,7 +485,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void Serialization_WithNullValues_HandlesNullsCorrectly()
+    public void SerializationWithNullValuesHandlesNullsCorrectly()
     {
         // Arrange
         var original = new TestMetadata
@@ -505,7 +493,7 @@ public sealed class TestMetadataTests
             MethodName = "TestMethod",
             ClassName = "TestClass",
             Namespace = "TestNamespace",
-            ProcessName = "testprocess",
+            ProcessName = "TestProcess",
             ProcessId = 1234,
             ClassAttributeNames = ["TestFixtureAttribute"],
             MethodAttributeNames = ["TestAttribute"],
@@ -522,7 +510,7 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void SerializationConstructor_WithNullSerializationInfo_ThrowsArgumentNullException()
+    public void SerializationConstructorWithNullSerializationInfoThrowsArgumentNullException()
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => 
@@ -530,32 +518,32 @@ public sealed class TestMetadataTests
     }
 
     [Test]
-    public void DebuggerDisplay_ForTestMethod_ReturnsCorrectFormat()
+    public void DebuggerDisplayForTestMethodReturnsCorrectFormat()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
             methodName: "TestMethod",
             className: "TestClass",
             namespaceName: "TestNamespace",
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234);
 
         // Act
         var debugDisplay = metadata.ToString(); // DebuggerDisplay uses the same logic as ToString
 
         // Assert
-        Assert.That(debugDisplay, Is.EqualTo("TestNamespace.TestClass.TestMethod [testprocess:1234]"));
+        Assert.That(debugDisplay, Is.EqualTo("TestNamespace.TestClass.TestMethod [TestProcess:1234]"));
     }
 
     [Test]
-    public void DebuggerDisplay_ForNonTestMethod_ReturnsProcessInfo()
+    public void DebuggerDisplayForNonTestMethodReturnsProcessInfo()
     {
         // Arrange
         var metadata = CreateTestMetadataUnderTest(
             methodName: string.Empty,
             className: string.Empty,
             namespaceName: string.Empty,
-            processName: "testprocess",
+            processName: "TestProcess",
             processId: 1234,
             methodAttributeNames: []);
 
@@ -563,11 +551,14 @@ public sealed class TestMetadataTests
         var debugDisplay = metadata.ToString(); // DebuggerDisplay uses the same logic as ToString
 
         // Assert
-        Assert.That(debugDisplay, Is.EqualTo("Process: testprocess (ID: 1234)"));
+        Assert.That(debugDisplay, Is.EqualTo("Process: TestProcess (ID: 1234)"));
     }
 
+    private static readonly string[] expected = new[] { "TestFixtureAttribute" };
+    private static readonly string[] expectedArray = new[] { "TestAttribute" };
+
     [Test]
-    public void Properties_WithInitValues_AreSetCorrectly()
+    public void PropertiesWithInitValuesAreSetCorrectly()
     {
         // Arrange & Act
         var metadata = new TestMetadata
@@ -575,7 +566,7 @@ public sealed class TestMetadataTests
             MethodName = "TestMethod",
             ClassName = "TestClass",
             Namespace = "TestNamespace",
-            ProcessName = "testprocess",
+            ProcessName = "TestProcess",
             ProcessId = 1234,
             ClassAttributeNames = ["TestFixtureAttribute"],
             MethodAttributeNames = ["TestAttribute"],
@@ -586,25 +577,25 @@ public sealed class TestMetadataTests
         Assert.That(metadata.MethodName, Is.EqualTo("TestMethod"));
         Assert.That(metadata.ClassName, Is.EqualTo("TestClass"));
         Assert.That(metadata.Namespace, Is.EqualTo("TestNamespace"));
-        Assert.That(metadata.ProcessName, Is.EqualTo("testprocess"));
+        Assert.That(metadata.ProcessName, Is.EqualTo("TestProcess"));
         Assert.That(metadata.ProcessId, Is.EqualTo(1234));
-        Assert.That(metadata.ClassAttributeNames, Is.EquivalentTo(new[] { "TestFixtureAttribute" }));
-        Assert.That(metadata.MethodAttributeNames, Is.EquivalentTo(new[] { "TestAttribute" }));
+        Assert.That(metadata.ClassAttributeNames, Is.EquivalentTo(expected));
+        Assert.That(metadata.MethodAttributeNames, Is.EquivalentTo(expectedArray));
         Assert.That(metadata.TestDescription, Is.EqualTo("Test Description"));
     }
 
-    private static byte[] SerializeToMemoryStream<T>(T obj) where T : ISerializable
+    private static byte[] SerializeToMemoryStream<T>(T obj)
     {
         using var memoryStream = new MemoryStream();
-        var formatter = new BinaryFormatter();
-        formatter.Serialize(memoryStream, obj);
+        var serializer = new DataContractSerializer(typeof(T), knownTypes: [typeof(string[])]);
+        serializer.WriteObject(memoryStream, obj);
         return memoryStream.ToArray();
     }
 
     private static T DeserializeFromMemoryStream<T>(byte[] data)
     {
         using var memoryStream = new MemoryStream(data);
-        var formatter = new BinaryFormatter();
-        return (T)formatter.Deserialize(memoryStream);
+        var serializer = new DataContractSerializer(typeof(T), knownTypes: [typeof(string[])]);
+        return (T)serializer.ReadObject(memoryStream)!;
     }
 }

--- a/tests/Xping.Sdk.Core.UnitTests/Session/TestMetadataTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/TestMetadataTests.cs
@@ -6,7 +6,6 @@
  */
 
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
 using Xping.Sdk.Core.Session;
 
 namespace Xping.Sdk.UnitTests.Session;


### PR DESCRIPTION
This PR mainly adds support for a new `TestMetadata` class.

**Core SDK Enhancements:**

- Added a new `TestMetadata` class encapsulating metadata about test methods and classes.
- Updated `ITestSessionBuilder` and related methods to handle `TestMetadata`.
- Extended `TestSession` and `TestSessionSerializer` to incorporate `TestMetadata`, enabling serialization and report enhancements.

**Test Agent Updates:**

- Adapted `TestAgent` to identify and use `TestMetadata` dynamically via stack trace analysis.

**Serialization Adjustments:**

- Improved the `TestSessionSerializer` class to include `TestMetadata` in known types and handle serialization effectively.