### PR TITLE
feature: Include HttpRequst details in TestSession. Update PropertyBagKeys for HTTP properties and enhance PropertyBagValue to support additional types

### DIFF
--- a/src/Xping.Sdk.Core/Clients/BaseConfiguration.cs
+++ b/src/Xping.Sdk.Core/Clients/BaseConfiguration.cs
@@ -185,7 +185,7 @@ public abstract class BaseConfiguration
     {
         ArgumentNullException.ThrowIfNull(httpContent, nameof(httpContent));
 
-        PropertyBag.AddOrUpdateProperty(PropertyBagKeys.HttpContent, httpContent);
+        PropertyBag.AddOrUpdateProperty(PropertyBagKeys.HttpRequestContent, httpContent);
 
         if (!setContentHeaders) 
             return;
@@ -223,7 +223,7 @@ public abstract class BaseConfiguration
     /// </returns>
     public HttpContent? GetHttpContent()
     {
-        if (PropertyBag.TryGetProperty(PropertyBagKeys.HttpContent, out HttpContent? httpContent))
+        if (PropertyBag.TryGetProperty(PropertyBagKeys.HttpRequestContent, out HttpContent? httpContent))
         {
             return httpContent;
         }
@@ -239,7 +239,7 @@ public abstract class BaseConfiguration
     /// </remarks>
     public void ClearHttpContent()
     {
-        PropertyBag.Clear(PropertyBagKeys.HttpContent);
+        PropertyBag.Clear(PropertyBagKeys.HttpRequestContent);
     }
 
     /// <summary>

--- a/src/Xping.Sdk.Core/Common/PropertyBagKeys.cs
+++ b/src/Xping.Sdk.Core/Common/PropertyBagKeys.cs
@@ -21,123 +21,139 @@ public static class PropertyBagKeys
     /// <summary>
     /// Represents IP address. See more on <see href="https://learn.microsoft.com/en-us/dotnet/api/system.net.ipaddress"/>.
     /// </summary>
-    public readonly static PropertyBagKey IPAddress = new(nameof(IPAddress));
+    public static readonly PropertyBagKey IPAddress = new(nameof(IPAddress));
     /// <summary>
     /// Represents IP status operation. See more on <see href="https://learn.microsoft.com/en-us/dotnet/api/system.net.networkinformation.ipstatus"/>.
     /// </summary>
-    public readonly static PropertyBagKey IPStatus = new(nameof(IPStatus));
+    public static readonly PropertyBagKey IPStatus = new(nameof(IPStatus));
     #endregion Network Information
 
     #region DNS Lookup
     /// <summary>
     /// Array of matching IP addresses associated with a DNS name of the host.
     /// </summary>
-    public readonly static PropertyBagKey DnsResolvedIPAddresses = new(nameof(DnsResolvedIPAddresses));
+    public static readonly PropertyBagKey DnsResolvedIPAddresses = new(nameof(DnsResolvedIPAddresses));
     #endregion DNS Lookup
 
     #region PING 
     /// <summary>
     /// Represents the number of times the ping data can be forwarded.
     /// </summary>
-    public readonly static PropertyBagKey PingTTLOption = new(nameof(PingTTLOption));
+    public static readonly PropertyBagKey PingTtlOption = new(nameof(PingTtlOption));
 
     /// <summary>
     /// Represents the boolean value that controls fragmentation of the data sent to the remote host.
     /// </summary>
-    public readonly static PropertyBagKey PingDontFragmetOption = new(nameof(PingDontFragmetOption));
+    public static readonly PropertyBagKey PingDontFragmentOption = new(nameof(PingDontFragmentOption));
 
     /// <summary>
     /// Represents the number of milliseconds taken to send an Internet Control Message Protocol (ICMP) echo request and 
     /// receive the corresponding ICMP echo reply message.
     /// </summary>
-    public readonly static PropertyBagKey PingRoundtripTime = new(nameof(PingRoundtripTime));
+    public static readonly PropertyBagKey PingRoundtripTime = new(nameof(PingRoundtripTime));
     #endregion PING
 
     #region HTTP
     /// <summary>
     /// Represents the HTTP response message.
     /// </summary>
-    public readonly static PropertyBagKey HttpResponseMessage = new(nameof(HttpResponseMessage));
+    public static readonly PropertyBagKey HttpResponseMessage = new(nameof(HttpResponseMessage));
 
     /// <summary>
     /// Represents the HTTP method.
     /// </summary>
-    public readonly static PropertyBagKey HttpMethod = new(nameof(HttpMethod));
-
+    public static readonly PropertyBagKey HttpMethod = new(nameof(HttpMethod));
+    
     /// <summary>
     /// Represents the HTTP status. 
     /// </summary>
-    public readonly static PropertyBagKey HttpStatus = new(nameof(HttpStatus));
+    public static readonly PropertyBagKey HttpResponseStatus = new(nameof(HttpResponseStatus));
 
     /// <summary>
     /// Represents the HTTP reason phrase.
     /// </summary>
-    public readonly static PropertyBagKey HttpReasonPhrase = new(nameof(HttpReasonPhrase));
+    public static readonly PropertyBagKey HttpResponsePhrase = new(nameof(HttpResponsePhrase));
 
     /// <summary>
     /// Represents the HTTP version.
     /// </summary>
-    public readonly static PropertyBagKey HttpVersion = new(nameof(HttpVersion));
+    public static readonly PropertyBagKey HttpResponseVersion = new(nameof(HttpResponseVersion));
 
     /// <summary>
     /// Represents the HTTP content.
     /// </summary>
-    public readonly static PropertyBagKey HttpContent = new(nameof(HttpContent));
+    public static readonly PropertyBagKey HttpResponseContent = new(nameof(HttpResponseContent));
+    
+    /// <summary>
+    /// Represents the HTTP content.
+    /// </summary>
+    public static readonly PropertyBagKey HttpRequestContent = new(nameof(HttpRequestContent));
 
     /// <summary>
     /// Represents the HTTP content headers.
     /// </summary>
-    public readonly static PropertyBagKey HttpContentHeaders = new(nameof(HttpContentHeaders));
+    public static readonly PropertyBagKey HttpContentHeaders = new(nameof(HttpContentHeaders));
+    
+    /// <summary>
+    /// Represents a value that specifies the maximum time to wait for a network request or a browser operation to
+    /// finish.
+    /// </summary>
+    public static readonly PropertyBagKey HttpRequestTimeout = new (nameof(HttpRequestTimeout));
 
     /// <summary>
-    /// Represents the boolean value determining whether to retry failing HTTP request.
+    /// Represents the boolean value determining whether to retry a failing HTTP request.
     /// </summary>
-    public readonly static PropertyBagKey HttpRetry = new(nameof(HttpRetry));
+    public static readonly PropertyBagKey HttpRetry = new(nameof(HttpRetry));
 
     /// <summary>
     /// Represents the boolean value that indicates whether to follow redirection responses.
     /// </summary>
-    public readonly static PropertyBagKey HttpFollowRedirect = new(nameof(HttpFollowRedirect));
+    public static readonly PropertyBagKey HttpFollowRedirect = new(nameof(HttpFollowRedirect));
+    
+    /// <summary>
+    /// Represents the maximum number of allowed HTTP redirects.
+    /// </summary>
+    public static readonly PropertyBagKey MaxRedirections = new(nameof(MaxRedirections));
 
     /// <summary>
-    /// Represents the collection of HTTP request headers as IDictionary&lt;string, IEnumerable&lt;string&gt;&gt;. 
+    /// Represents the collection of HTTP request headers as IDictionary&lt;string, IEnumerable&lt;string&gt;&gt; 
     /// </summary>
-    public readonly static PropertyBagKey HttpRequestHeaders = new(nameof(HttpRequestHeaders));
+    public static readonly PropertyBagKey HttpRequestHeaders = new(nameof(HttpRequestHeaders));
 
     /// <summary>
     /// Represents the collection of HTTP response headers as 
     /// <see href="https://learn.microsoft.com/en-us/dotnet/api/system.net.http.headers.httpresponseheaders"/>.
     /// </summary>
-    public readonly static PropertyBagKey HttpResponseHeaders = new(nameof(HttpResponseHeaders));
+    public static readonly PropertyBagKey HttpResponseHeaders = new(nameof(HttpResponseHeaders));
 
     /// <summary>
     /// Represents the collection of trailing headers included in an HTTP response as
     /// <see href="https://learn.microsoft.com/en-us/dotnet/api/system.net.http.headers.httpresponseheaders"/>.
     /// </summary>
-    public readonly static PropertyBagKey HttpResponseTrailingHeaders = new(nameof(HttpResponseTrailingHeaders));
+    public static readonly PropertyBagKey HttpResponseTrailingHeaders = new(nameof(HttpResponseTrailingHeaders));
     #endregion HTTP
 
     #region BROWSER
     /// <summary>
-    /// Represents the coordinates of the geographical location of a device.
+    /// Represents the coordinates of the device geographical location.
     /// </summary>
     /// <remarks>
     /// This property key is used to access the geolocation details in the context of automated browser tests.
-    /// It leverages the Geolocation feature from the Playwright library to simulate the geographical position
+    /// It leverages the Geolocation feature from the Playwright library to simulate the geographical position,
     /// which can be useful for testing location-based functionalities of web applications.
     /// </remarks>
-    public readonly static PropertyBagKey Geolocation = new(nameof(Geolocation));
+    public static readonly PropertyBagKey Geolocation = new(nameof(Geolocation));
 
     /// <summary>
     /// Represents the <see cref="BrowserResponseMessage"/>.
     /// </summary>
-    public readonly static PropertyBagKey BrowserResponseMessage = new(nameof(BrowserResponseMessage));
+    public static readonly PropertyBagKey BrowserResponseMessage = new(nameof(BrowserResponseMessage));
     #endregion BROWSER
 
     #region HTML_VALIDATION
     /// <summary>
-    /// Represents the name of the html validation method invoked.
+    /// Represents the name of the HTML validation method invoked.
     /// </summary>
-    public readonly static PropertyBagKey MethodName = new(nameof(MethodName));
+    public static readonly PropertyBagKey MethodName = new(nameof(MethodName));
     #endregion HTML_VALIDATION
 }

--- a/src/Xping.Sdk.Core/Session/Serialization/TestSessionSerializer.cs
+++ b/src/Xping.Sdk.Core/Session/Serialization/TestSessionSerializer.cs
@@ -87,6 +87,11 @@ public sealed class TestSessionSerializer : ITestSessionSerializer
         typeof(PropertyBagValue<byte[]>),
         typeof(PropertyBagValue<string>),
         typeof(PropertyBagValue<string[]>),
-        typeof(PropertyBagValue<Dictionary<string, string>>)
+        typeof(PropertyBagValue<Dictionary<string, string>>),
+        typeof(PropertyBagValue<int>),
+        typeof(PropertyBagValue<double>),
+        typeof(PropertyBagValue<bool>),
+        typeof(PropertyBagValue<DateTime>),
+        typeof(PropertyBagValue<TimeSpan>)
     ];
 }

--- a/src/Xping.Sdk/Actions/BrowserRequestSender.cs
+++ b/src/Xping.Sdk/Actions/BrowserRequestSender.cs
@@ -103,13 +103,13 @@ public sealed class BrowserRequestSender : TestComponent
 
             HttpResponseMessage Response() => responseMessage.HttpResponseMessage;
             testStep = context.SessionBuilder
-                .Build(PropertyBagKeys.HttpStatus, new PropertyBagValue<string>($"{(int)Response().StatusCode}"))
-                .Build(PropertyBagKeys.HttpVersion, new PropertyBagValue<string>($"{Response().Version}"))
-                .Build(PropertyBagKeys.HttpReasonPhrase, new PropertyBagValue<string?>(Response().ReasonPhrase))
+                .Build(PropertyBagKeys.HttpResponseStatus, new PropertyBagValue<string>($"{(int)Response().StatusCode}"))
+                .Build(PropertyBagKeys.HttpResponseVersion, new PropertyBagValue<string>($"{Response().Version}"))
+                .Build(PropertyBagKeys.HttpResponsePhrase, new PropertyBagValue<string?>(Response().ReasonPhrase))
                 .Build(PropertyBagKeys.HttpResponseHeaders, GetHeaders(Response().Headers))
                 .Build(PropertyBagKeys.HttpResponseTrailingHeaders, GetHeaders(Response().TrailingHeaders))
                 .Build(PropertyBagKeys.HttpContentHeaders, GetHeaders(Response().Content.Headers))
-                .Build(PropertyBagKeys.HttpContent, new PropertyBagValue<byte[]>(buffer))
+                .Build(PropertyBagKeys.HttpResponseContent, new PropertyBagValue<byte[]>(buffer))
                 .Build(PropertyBagKeys.BrowserResponseMessage,
                     new NonSerializable<BrowserResponseMessage>(responseMessage))
                 .Build(PropertyBagKeys.HttpResponseMessage, 

--- a/src/Xping.Sdk/Actions/Internals/BrowserRedirectionResponseHandler.cs
+++ b/src/Xping.Sdk/Actions/Internals/BrowserRedirectionResponseHandler.cs
@@ -92,8 +92,8 @@ internal class BrowserRedirectionResponseHandler : IHttpResponseHandler
         var httpStatucCode = Enum.Parse<HttpStatusCode>($"{response.Status}", ignoreCase: true);
 
         var testStep = _context.SessionBuilder
-            .Build(PropertyBagKeys.HttpStatus, new PropertyBagValue<string>($"{(int)httpStatucCode}"))
-            .Build(PropertyBagKeys.HttpReasonPhrase, new PropertyBagValue<string?>(response.StatusText))
+            .Build(PropertyBagKeys.HttpResponseStatus, new PropertyBagValue<string>($"{(int)httpStatucCode}"))
+            .Build(PropertyBagKeys.HttpResponsePhrase, new PropertyBagValue<string?>(response.StatusText))
             .Build(PropertyBagKeys.HttpResponseHeaders, httpHeadersBag)
             .Build();
 

--- a/src/Xping.Sdk/Validations/Content/BaseContentValidator.cs
+++ b/src/Xping.Sdk/Validations/Content/BaseContentValidator.cs
@@ -75,7 +75,7 @@ public abstract class BaseContentValidator(string name) : TestComponent(name, Te
     /// </remarks>
     protected virtual byte[] GetData(TestContext context)
     {
-        return context.GetPropertyBagValue<byte[]>(PropertyBagKeys.HttpContent) ?? [];
+        return context.GetPropertyBagValue<byte[]>(PropertyBagKeys.HttpResponseContent) ?? [];
     }
     
     /// <summary>

--- a/tests/Xping.Sdk.Availability.UnitTests/Validations/Content/Html/HtmlContentValidatorTests.cs
+++ b/tests/Xping.Sdk.Availability.UnitTests/Validations/Content/Html/HtmlContentValidatorTests.cs
@@ -130,7 +130,7 @@ public sealed class HtmlContentValidatorTests
     {
         // Arrange
         var testStep = HtmlContentTestsHelpers.CreateTestStep(
-            PropertyBagKeys.HttpContent,
+            PropertyBagKeys.HttpResponseContent,
             new PropertyBagValue<byte[]>(Encoding.UTF8.GetBytes("Data")));
 
         var validator = new HtmlContentValidator((IHtmlContent content) => { });
@@ -181,7 +181,7 @@ public sealed class HtmlContentValidatorTests
             new Dictionary<PropertyBagKey, IPropertyBagValue>()
             {
                 { PropertyBagKeys.HttpResponseMessage, new NonSerializable<HttpResponseMessage>(httpResponseMessage) },
-                { PropertyBagKeys.HttpContent, new PropertyBagValue<byte[]>(Encoding.UTF8.GetBytes("Data")) }
+                { PropertyBagKeys.HttpResponseContent, new PropertyBagValue<byte[]>(Encoding.UTF8.GetBytes("Data")) }
             });
 
         bool validationCalled = false;
@@ -209,7 +209,7 @@ public sealed class HtmlContentValidatorTests
             new Dictionary<PropertyBagKey, IPropertyBagValue>()
             {
                 { PropertyBagKeys.HttpResponseMessage, new NonSerializable<HttpResponseMessage>(httpResponseMessage) },
-                { PropertyBagKeys.HttpContent, new PropertyBagValue<byte[]>(Encoding.UTF8.GetBytes("Data")) }
+                { PropertyBagKeys.HttpResponseContent, new PropertyBagValue<byte[]>(Encoding.UTF8.GetBytes("Data")) }
             });
 
         var validator = new HtmlContentValidator((IHtmlContent content) =>
@@ -243,7 +243,7 @@ public sealed class HtmlContentValidatorTests
             new Dictionary<PropertyBagKey, IPropertyBagValue>()
             {
                 { PropertyBagKeys.HttpResponseMessage, new NonSerializable<HttpResponseMessage>(httpResponseMessage) },
-                { PropertyBagKeys.HttpContent, new PropertyBagValue<byte[]>(Encoding.UTF8.GetBytes(expectedData)) }
+                { PropertyBagKeys.HttpResponseContent, new PropertyBagValue<byte[]>(Encoding.UTF8.GetBytes(expectedData)) }
             });
         var receivedContent = string.Empty;
         var validatorUnderTest = new HtmlContentValidatorUnderTest(_ => { })

--- a/tests/Xping.Sdk.Core.UnitTests/Session/Comparison/TestStepsComparerTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/Comparison/TestStepsComparerTests.cs
@@ -518,7 +518,7 @@ public sealed class TestStepsComparerTests : ComparerBaseTests<TestStepsComparer
         const string StepName = "StepName";
         var properties = new Dictionary<PropertyBagKey, IPropertyBagValue>
         {
-            { PropertyBagKeys.HttpStatus, new PropertyBagValue<string>("value") }
+            { PropertyBagKeys.HttpResponseStatus, new PropertyBagValue<string>("value") }
         };
 
         // Arrange
@@ -547,7 +547,7 @@ public sealed class TestStepsComparerTests : ComparerBaseTests<TestStepsComparer
         const string StepName = "StepName";
         var properties1 = new Dictionary<PropertyBagKey, IPropertyBagValue>
         {
-            { PropertyBagKeys.HttpStatus, new PropertyBagValue<string>("value") }
+            { PropertyBagKeys.HttpResponseStatus, new PropertyBagValue<string>("value") }
         };
 
         var properties2 = new Dictionary<PropertyBagKey, IPropertyBagValue>
@@ -579,7 +579,7 @@ public sealed class TestStepsComparerTests : ComparerBaseTests<TestStepsComparer
         Assert.That(
             result.Differences.First().PropertyName,
             Is.EqualTo($"{nameof(TestStep)}(\"{StepName}\").{nameof(TestStep.PropertyBag)}" +
-            $"[\"{nameof(PropertyBagKeys.HttpStatus)}\"]"));
+            $"[\"{nameof(PropertyBagKeys.HttpResponseStatus)}\"]"));
 
         Assert.That(result.Differences.Last().Type, Is.EqualTo(DifferenceType.Added));
         Assert.That(result.Differences.Last().Value1, Is.Null);
@@ -594,7 +594,7 @@ public sealed class TestStepsComparerTests : ComparerBaseTests<TestStepsComparer
     public void CompareShouldReturnDiffResultEmptyWhenPropertyBagsHasDifferentValues()
     {
         const string StepName = "StepName";
-        PropertyBagKey key = PropertyBagKeys.HttpStatus;
+        PropertyBagKey key = PropertyBagKeys.HttpResponseStatus;
 
         var properties1 = new Dictionary<PropertyBagKey, IPropertyBagValue>
         {

--- a/tests/Xping.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
+++ b/tests/Xping.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
@@ -128,7 +128,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
 
         Assert.Multiple(() =>
         {
-            Assert.That(session.TryGetPropertyBagValue(PropertyBagKeys.HttpStatus, out code), Is.True);
+            Assert.That(session.TryGetPropertyBagValue(PropertyBagKeys.HttpResponseStatus, out code), Is.True);
             Assert.That(Enum.Parse<HttpStatusCode>(code!.Value), Is.EqualTo(httpStatusCode));
         });
     }
@@ -388,7 +388,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
 
         Assert.Multiple(() =>
         {
-            Assert.That(session.TryGetPropertyBagValue(PropertyBagKeys.HttpContent, out byteArray), Is.True);
+            Assert.That(session.TryGetPropertyBagValue(PropertyBagKeys.HttpResponseContent, out byteArray), Is.True);
             Assert.That(byteArray is not null && Encoding.UTF8.GetString(byteArray.Value) == responseContent);
         });
     }
@@ -464,11 +464,11 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
         var destinationStep = httpRequestSteps.Last();
 
         var redirectionStatusCode = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
-            PropertyBagKeys.HttpStatus).Value;
+            PropertyBagKeys.HttpResponseStatus).Value;
         var redirectionUrl = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<Dictionary<string, string>>>(
             PropertyBagKeys.HttpResponseHeaders).Value[HeaderNames.Location.ToUpperInvariant()];
         var destinationStatusCode = destinationStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
-            PropertyBagKeys.HttpStatus).Value;
+            PropertyBagKeys.HttpResponseStatus).Value;
 
         Assert.Multiple(() =>
         {
@@ -507,7 +507,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
         var destinationStep = httpRequestSteps.Last();
 
         var redirectionStatusCode = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
-            PropertyBagKeys.HttpStatus).Value;
+            PropertyBagKeys.HttpResponseStatus).Value;
         var redirectionUrl = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<Dictionary<string, string>>>(
             PropertyBagKeys.HttpResponseHeaders).Value[HeaderNames.Location.ToUpperInvariant()];
 
@@ -636,7 +636,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
         var destinationStep = httpRequestSteps.Last();
 
         var destinationStatusCode = destinationStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
-            PropertyBagKeys.HttpStatus).Value;
+            PropertyBagKeys.HttpResponseStatus).Value;
         var destinationUrl = destinationStep.PropertyBag!.GetProperty<NonSerializable<HttpResponseMessage>>(
             PropertyBagKeys.HttpResponseMessage).Value;
 

--- a/tests/Xping.Sdk.IntegrationTests/BrowserTestAgentTests.cs
+++ b/tests/Xping.Sdk.IntegrationTests/BrowserTestAgentTests.cs
@@ -419,7 +419,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
 
         Assert.Multiple(() =>
         {
-            Assert.That(session.TryGetPropertyBagValue(PropertyBagKeys.HttpContent, out byteArray), Is.True);
+            Assert.That(session.TryGetPropertyBagValue(PropertyBagKeys.HttpResponseContent, out byteArray), Is.True);
             Assert.That(byteArray is not null);
         });
     }
@@ -435,7 +435,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
                 responseBuilder: JavascriptPageResponseBuilder)
             .ConfigureAwait(false);
 
-        var byteArray = session.GetPropertyBagValue<byte[]>(PropertyBagKeys.HttpContent);
+        var byteArray = session.GetPropertyBagValue<byte[]>(PropertyBagKeys.HttpResponseContent);
         var content = Encoding.UTF8.GetString(byteArray!);
 
         // Assert
@@ -484,11 +484,11 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
             var destinationStep = httpRequestSteps.Last();
 
             var redirectionStatusCode = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
-                PropertyBagKeys.HttpStatus).Value;
+                PropertyBagKeys.HttpResponseStatus).Value;
             var redirectionUrl = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<Dictionary<string, string>>>(
                 PropertyBagKeys.HttpResponseHeaders).Value[HeaderNames.Location.ToUpperInvariant()];
             var destinationStatusCode = destinationStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
-                PropertyBagKeys.HttpStatus).Value;
+                PropertyBagKeys.HttpResponseStatus).Value;
 
             Assert.Multiple(() =>
             {
@@ -531,7 +531,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
         var destinationStep = httpRequestSteps.Last();
 
         var redirectionStatusCode = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
-            PropertyBagKeys.HttpStatus).Value;
+            PropertyBagKeys.HttpResponseStatus).Value;
         var redirectionUrl = redirectionStep.PropertyBag!.GetProperty<PropertyBagValue<Dictionary<string, string>>>(
             PropertyBagKeys.HttpResponseHeaders).Value[HeaderNames.Location.ToUpperInvariant()];
 
@@ -666,7 +666,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
         var destinationStep = httpRequestSteps.Last();
 
         var destinationStatusCode = destinationStep.PropertyBag!.GetProperty<PropertyBagValue<string>>(
-            PropertyBagKeys.HttpStatus).Value;
+            PropertyBagKeys.HttpResponseStatus).Value;
         var destinationUrl = destinationStep.PropertyBag!.GetProperty<NonSerializable<BrowserResponseMessage>>(
             PropertyBagKeys.BrowserResponseMessage).Value;
 


### PR DESCRIPTION
This Pull Request introduces several updates to the handling of HTTP-related properties, enhances data type serialization, and improves code clarity by refactoring. It also adjusts integration and unit tests to reflect these changes.

**Key Changes:**

- **Renamed Property Keys:** Updated multiple HTTP-related property keys for consistency (e.g., HttpContent to HttpRequestContent, HttpStatus to HttpResponseStatus).

- **Added Support for New Data Types:** Enhanced PropertyBagValue to support serialization of additional types (int, double, bool, DateTime, TimeSpan).

- **Refactored Methods:** Split larger methods into smaller helper methods for validation, HttpClient initialization, and request/response handling in HttpClientRequestSender.

- **Test Updates:**

    - Adjusted integration and unit tests to match the renamed property keys.

    - Extended type testing for newly supported data types.

- **General Improvements:** Fixed naming inconsistencies, improved documentation, and added culture-specific formatting for proper serialization.