### PR TITLE
Add ApiKey property to TestAgent for Xping.io authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Host.CreateDefaultBuilder()
         .AddTestAgent(agent =>
         {
             agent.UploadToken = "--- Your Dashboard Upload Token ---";
+            agent.ApiKey = "--- Your Dashboard API Key ---"; // For authentication with Xping services
             agent.UseDnsLookup()
                  .UseIPAddressAccessibilityCheck()
                  .UseHttpClient()
@@ -117,6 +118,7 @@ public class HomePageTests(TestAgent testAgent) : XpingAssertions
     public void OneTimeSetUp()
     {
         testAgent.UploadToken = "--- Your Dashboard Upload Token ---";
+        testAgent.ApiKey = "--- Your Dashboard API Key ---"; // For authentication with Xping services
     }
 
     [Test]
@@ -143,6 +145,37 @@ That’s it! You’re now ready to start automating your web application tests a
 ## Usage
 
 The `samples` folder in this repository contains various examples of how to use Xping SDK for your testing needs. For a comprehensive guide on how to install, configure, and customize Xping SDK, please refer to the [docs](https://xping-dev.github.io/sdk-dotnet/index.html).
+
+<p align="right">(<a href="#top">back to top</a>)</p>
+
+
+<!-- CONFIGURATION -->
+## Configuration
+
+### Authentication
+
+Xping SDK supports authentication with Xping services using an API key. This key is used to authenticate requests when uploading test results to your dashboard.
+
+#### Setting the API Key
+
+You can set the API key in two ways:
+
+**Method 1: Explicitly in code**
+```csharp
+services.AddTestAgent(agent =>
+{
+    agent.ApiKey = "your-api-key-here";
+});
+```
+
+**Method 2: Using environment variable (recommended for CI/CD)**
+```bash
+export XPING_API_KEY="your-api-key-here"
+```
+
+When using environment variables, you don't need to set the API key explicitly in your code. The SDK will automatically read the value from the `XPING_API_KEY` environment variable.
+
+**Note:** If you set the API key explicitly in code, it will take precedence over the environment variable.
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 

--- a/nuspec/README.md
+++ b/nuspec/README.md
@@ -35,6 +35,7 @@ Host.CreateDefaultBuilder()
         .AddTestAgent(agent =>
         {
             agent.UploadToken = "--- Your Dashboard Upload Token ---";
+            agent.ApiKey = "--- Your Dashboard API Key ---"; // For authentication with Xping services
             agent.UseDnsLookup()
                  .UseIPAddressAccessibilityCheck()
                  .UseHttpClient()
@@ -70,6 +71,7 @@ public class HomePageTests(TestAgent testAgent) : XpingAssertions
     public void OneTimeSetUp()
     {
         TestAgent.UploadToken = "--- Your Dashboard Upload Token ---"; // optional
+        TestAgent.ApiKey = "--- Your Dashboard API Key ---"; // For authentication with Xping services
     }
 
     [Test]

--- a/samples/ConsoleAppTesting/Program.cs
+++ b/samples/ConsoleAppTesting/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 using Xping.Sdk;
 using Xping.Sdk.Core;
+using Xping.Sdk.Core.Components;
 using Xping.Sdk.Core.DependencyInjection;
 using Xping.Sdk.Core.Session;
 using Xping.Sdk.Extensions;
@@ -82,6 +83,11 @@ internal sealed class Program : XpingAssertions
                         .AddTestAgent(agent =>
                         {
                             agent.UploadToken = "--- Your Dashboard Upload Token ---";
+                            // API Key for authentication with Xping services
+                            // Can be set explicitly or read from XPING_API_KEY environment variable
+                            agent.ApiKey = "--- Your Dashboard API Key ---";
+                            // Or alternatively, set the XPING_API_KEY environment variable
+                            // and the API key will be automatically loaded
                         });
             })
             .ConfigureLogging(logging =>

--- a/src/Xping.Sdk.Core/Session/Collector/ITestSessionUploader.cs
+++ b/src/Xping.Sdk.Core/Session/Collector/ITestSessionUploader.cs
@@ -20,9 +20,10 @@ public interface ITestSessionUploader
     /// Asynchronously uploads a test session to the xping.io server.
     /// </summary>
     /// <param name="testSession">The test session to upload.</param>
+    /// <param name="apiKey">The API key for authentication. If null, no authentication header will be added.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>
     /// A task that represents the asynchronous upload operation, containing the upload result with status information.
     /// </returns>
-    Task<UploadResult> UploadAsync(TestSession testSession, CancellationToken cancellationToken = default);
+    Task<UploadResult> UploadAsync(TestSession testSession, string? apiKey = null, CancellationToken cancellationToken = default);
 }

--- a/src/Xping.Sdk.Core/Session/Collector/TestSessionUploader.cs
+++ b/src/Xping.Sdk.Core/Session/Collector/TestSessionUploader.cs
@@ -17,11 +17,19 @@ internal class TestSessionUploader(
 {
     public async Task<UploadResult> UploadAsync(
         TestSession testSession,
+        string? apiKey = null,
         CancellationToken cancellationToken = default)
     {
         try
         {
             using var httpClient = factory.CreateClient(HttpClientFactoryConfiguration.HttpClientUploadSession);
+            
+            // Add API key to request headers if provided
+            if (!string.IsNullOrWhiteSpace(apiKey))
+            {
+                httpClient.DefaultRequestHeaders.Add("x-api-key", apiKey);
+            }
+            
             using var form = new MultipartFormDataContent();
             using MemoryStream memoryStream = new();
             

--- a/src/Xping.Sdk.Core/TestAgent.cs
+++ b/src/Xping.Sdk.Core/TestAgent.cs
@@ -57,6 +57,7 @@ public sealed class TestAgent : IDisposable
 {
     private bool _disposedValue;
     private Guid _uploadToken;
+    private string? _apiKey;
 
     private readonly IServiceProvider _serviceProvider;
 
@@ -92,6 +93,17 @@ public sealed class TestAgent : IDisposable
                               Guid.TryParse(value, out Guid result)
             ? result
             : Guid.Empty;
+    }
+
+    /// <summary>
+    /// Gets or sets the API key used for authentication with Xping services when uploading data.
+    /// If not explicitly set, the value is read from the XPING_API_KEY environment variable.
+    /// This key is used to authenticate HTTP requests by adding it as the "x-api-key" header.
+    /// </summary>
+    public string? ApiKey
+    {
+        get => _apiKey ?? Environment.GetEnvironmentVariable("XPING_API_KEY");
+        set => _apiKey = value;
     }
 
     /// <summary>
@@ -353,7 +365,7 @@ public sealed class TestAgent : IDisposable
         ITestSessionUploader sessionUploader,
         CancellationToken cancellationToken)
     {
-        var result = await sessionUploader.UploadAsync(testSession, cancellationToken).ConfigureAwait(false);
+        var result = await sessionUploader.UploadAsync(testSession, ApiKey, cancellationToken).ConfigureAwait(false);
 
         if (!result.IsSuccessful)
         {

--- a/tests/Xping.Sdk.Core.UnitTests/TestAgentApiKeyTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/TestAgentApiKeyTests.cs
@@ -1,0 +1,123 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * This file is part of the Xping SDK.
+ *
+ * License: [MIT]
+ */
+
+using NUnit.Framework;
+using Xping.Sdk.Core;
+
+namespace Xping.Sdk.Core.UnitTests;
+
+[TestFixture]
+public class TestAgentApiKeyTests
+{
+    [Test]
+    public void ApiKeyWhenSetExplicitlyReturnsSetValue()
+    {
+        // Arrange
+        using var testAgent = new TestAgent(serviceProvider: null!);
+        const string expectedApiKey = "test-api-key-123";
+
+        // Act
+        testAgent.ApiKey = expectedApiKey;
+
+        // Assert
+        Assert.That(testAgent.ApiKey, Is.EqualTo(expectedApiKey));
+    }
+
+    [Test]
+    public void ApiKeyWhenNotSetReturnsEnvironmentVariable()
+    {
+        // Arrange
+        using var testAgent = new TestAgent(serviceProvider: null!);
+        const string expectedApiKey = "env-api-key-456";
+        
+        // Set environment variable
+        Environment.SetEnvironmentVariable("XPING_API_KEY", expectedApiKey);
+        
+        try
+        {
+            // Act
+            var actualApiKey = testAgent.ApiKey;
+
+            // Assert
+            Assert.That(actualApiKey, Is.EqualTo(expectedApiKey));
+        }
+        finally
+        {
+            // Clean up
+            Environment.SetEnvironmentVariable("XPING_API_KEY", null);
+        }
+    }
+
+    [Test]
+    public void ApiKeyWhenExplicitlySetToNullReturnsEnvironmentVariable()
+    {
+        // Arrange
+        using var testAgent = new TestAgent(serviceProvider: null!);
+        const string expectedApiKey = "env-api-key-789";
+        
+        // Set environment variable
+        Environment.SetEnvironmentVariable("XPING_API_KEY", expectedApiKey);
+        
+        try
+        {
+            // Act
+            testAgent.ApiKey = null;
+            var actualApiKey = testAgent.ApiKey;
+
+            // Assert
+            Assert.That(actualApiKey, Is.EqualTo(expectedApiKey));
+        }
+        finally
+        {
+            // Clean up
+            Environment.SetEnvironmentVariable("XPING_API_KEY", null);
+        }
+    }
+
+    [Test]
+    public void ApiKeyWhenNeitherSetNorEnvironmentVariableReturnsNull()
+    {
+        // Arrange
+        using var testAgent = new TestAgent(serviceProvider: null!);
+        
+        // Ensure environment variable is not set
+        Environment.SetEnvironmentVariable("XPING_API_KEY", null);
+        
+        // Act
+        var actualApiKey = testAgent.ApiKey;
+
+        // Assert
+        Assert.That(actualApiKey, Is.Null);
+    }
+
+    [Test]
+    public void ApiKeyExplicitValueTakesPrecedenceOverEnvironmentVariable()
+    {
+        // Arrange
+        using var testAgent = new TestAgent(serviceProvider: null!);
+        const string explicitApiKey = "explicit-api-key";
+        const string envApiKey = "env-api-key";
+        
+        // Set environment variable
+        Environment.SetEnvironmentVariable("XPING_API_KEY", envApiKey);
+        
+        try
+        {
+            // Act
+            testAgent.ApiKey = explicitApiKey;
+            var actualApiKey = testAgent.ApiKey;
+
+            // Assert
+            Assert.That(actualApiKey, Is.EqualTo(explicitApiKey));
+        }
+        finally
+        {
+            // Clean up
+            Environment.SetEnvironmentVariable("XPING_API_KEY", null);
+        }
+    }
+}


### PR DESCRIPTION
Introduce an `ApiKey` property in the `TestAgent` class to facilitate authentication with Xping.io. The property retrieves its value from the `XPING_API_KEY` environment variable, supporting both local development and CI/CD pipelines. Update documentation to include configuration examples for setting the API key explicitly or via environment variables.

Fixes #20