### PR TITLE
Add ProcessArguments to TestMetadata for enhanced process information handling

### DIFF
--- a/src/Xping.Sdk.Core/Session/TestMetadata.cs
+++ b/src/Xping.Sdk.Core/Session/TestMetadata.cs
@@ -44,6 +44,11 @@ public sealed class TestMetadata : ISerializable, IDeserializationCallback, IEqu
     public string ProcessName { get; init; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the arguments passed to the process executing the test.
+    /// </summary>
+    public string ProcessArguments { get; init; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the process ID of the executing process.
     /// </summary>
     public int ProcessId { get; init; }
@@ -116,6 +121,7 @@ public sealed class TestMetadata : ISerializable, IDeserializationCallback, IEqu
         ClassName = info.GetString(nameof(ClassName)) ?? string.Empty;
         Namespace = info.GetString(nameof(Namespace)) ?? string.Empty;
         ProcessName = info.GetString(nameof(ProcessName)) ?? string.Empty;
+        ProcessArguments = info.GetString(nameof(ProcessArguments)) ?? string.Empty;
         ProcessId = info.GetInt32(nameof(ProcessId));
         ClassAttributeNames =
             (info.GetValue(nameof(ClassAttributeNames), typeof(string[])) as string[])?.ToList() ?? [];
@@ -171,11 +177,17 @@ public sealed class TestMetadata : ISerializable, IDeserializationCallback, IEqu
         {
             var description = !string.IsNullOrEmpty(TestDescription) ? $" - {TestDescription}" : "";
             var location = Location != null ? $" [{Location.Country}/{Location.Region}]" : "";
-            return $"{FullyQualifiedName}{description}{location} [{ProcessName}:{ProcessId}]";
+            var processInfo = !string.IsNullOrEmpty(ProcessArguments) 
+                ? $"{ProcessName} {ProcessArguments}" 
+                : ProcessName;
+            return $"{FullyQualifiedName}{description}{location} [{processInfo}:{ProcessId}]";
         }
 
         var locationInfo = Location != null ? $" [{Location.Country}/{Location.Region}]" : "";
-        return $"Process: {ProcessName} (ID: {ProcessId}){locationInfo}";
+        var processDisplay = !string.IsNullOrEmpty(ProcessArguments) 
+            ? $"{ProcessName} {ProcessArguments}" 
+            : ProcessName;
+        return $"Process: {processDisplay} (ID: {ProcessId}){locationInfo}";
     }
 
     /// <summary>
@@ -202,6 +214,7 @@ public sealed class TestMetadata : ISerializable, IDeserializationCallback, IEqu
                ClassName == other.ClassName &&
                Namespace == other.Namespace &&
                ProcessName == other.ProcessName &&
+               ProcessArguments == other.ProcessArguments &&
                ProcessId == other.ProcessId;
     }
 
@@ -211,7 +224,7 @@ public sealed class TestMetadata : ISerializable, IDeserializationCallback, IEqu
     /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
     public override int GetHashCode()
     {
-        return HashCode.Combine(MethodName, ClassName, Namespace, ProcessName, ProcessId);
+        return HashCode.Combine(MethodName, ClassName, Namespace, ProcessName, ProcessArguments, ProcessId);
     }
 
     /// <summary>
@@ -236,6 +249,7 @@ public sealed class TestMetadata : ISerializable, IDeserializationCallback, IEqu
         info.AddValue(nameof(ClassName), ClassName);
         info.AddValue(nameof(Namespace), Namespace);
         info.AddValue(nameof(ProcessName), ProcessName);
+        info.AddValue(nameof(ProcessArguments), ProcessArguments);
         info.AddValue(nameof(ProcessId), ProcessId);
         info.AddValue(nameof(ClassAttributeNames), ClassAttributeNames.ToArray());
         info.AddValue(nameof(MethodAttributeNames), MethodAttributeNames.ToArray());
@@ -251,8 +265,12 @@ public sealed class TestMetadata : ISerializable, IDeserializationCallback, IEqu
 
     private string GetDebuggerDisplay()
     {
+        var processDisplay = !string.IsNullOrEmpty(ProcessArguments) 
+            ? $"{ProcessName} {ProcessArguments}" 
+            : ProcessName;
+        
         return IsTestMethod
-            ? $"{FullyQualifiedName} [{ProcessName}:{ProcessId}]"
-            : $"Process: {ProcessName} (ID: {ProcessId})";
+            ? $"{FullyQualifiedName} [{processDisplay}:{ProcessId}]"
+            : $"Process: {processDisplay} (ID: {ProcessId})";
     }
 }

--- a/src/Xping.Sdk.Core/Session/TestSession.cs
+++ b/src/Xping.Sdk.Core/Session/TestSession.cs
@@ -217,7 +217,11 @@ public sealed class TestSession :
                 sb.AppendLine(CultureInfo.InvariantCulture, $"Test: {Metadata.DisplayName}");
                 sb.AppendLine(CultureInfo.InvariantCulture, $"Method: {Metadata.FullyQualifiedName}");
             }
-            sb.AppendLine(CultureInfo.InvariantCulture, $"Process: {Metadata.ProcessName} (ID: {Metadata.ProcessId})");
+            
+            var processDisplay = !string.IsNullOrEmpty(Metadata.ProcessArguments) 
+                ? $"{Metadata.ProcessName} {Metadata.ProcessArguments}" 
+                : Metadata.ProcessName;
+            sb.AppendLine(CultureInfo.InvariantCulture, $"Process: {processDisplay} (ID: {Metadata.ProcessId})");
             sb.AppendLine();
         }
 

--- a/tests/Xping.Sdk.Core.UnitTests/Session/TestMetadataTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/TestMetadataTests.cs
@@ -18,6 +18,7 @@ public sealed class TestMetadataTests
         string className = "TestClass",
         string namespaceName = "TestNamespace",
         string processName = "TestProcess",
+        string processArguments = "",
         int processId = 1234,
         IReadOnlyCollection<string>? classAttributeNames = null,
         IReadOnlyCollection<string>? methodAttributeNames = null,
@@ -30,6 +31,7 @@ public sealed class TestMetadataTests
             ClassName = className,
             Namespace = namespaceName,
             ProcessName = processName,
+            ProcessArguments = processArguments,
             ProcessId = processId,
             ClassAttributeNames = classAttributeNames ?? ["TestFixtureAttribute"],
             MethodAttributeNames = methodAttributeNames ?? ["TestAttribute"],
@@ -500,6 +502,7 @@ public sealed class TestMetadataTests
             ClassName = "TestClass",
             Namespace = "TestNamespace",
             ProcessName = "TestProcess",
+            ProcessArguments = "",
             ProcessId = 1234,
             ClassAttributeNames = ["TestFixtureAttribute"],
             MethodAttributeNames = ["TestAttribute"],
@@ -573,6 +576,7 @@ public sealed class TestMetadataTests
             ClassName = "TestClass",
             Namespace = "TestNamespace",
             ProcessName = "TestProcess",
+            ProcessArguments = "",
             ProcessId = 1234,
             ClassAttributeNames = ["TestFixtureAttribute"],
             MethodAttributeNames = ["TestAttribute"],
@@ -627,5 +631,49 @@ public sealed class TestMetadataTests
 
         // Act & Assert
         Assert.That(original.XpingIdentifier, Is.Not.Null);
+    }
+
+    [Test]
+    public void ProcessArgumentsAreHandledCorrectly()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            processName: "dotnet",
+            processArguments: "test --logger console");
+
+        // Act & Assert
+        Assert.That(metadata.ProcessName, Is.EqualTo("dotnet"));
+        Assert.That(metadata.ProcessArguments, Is.EqualTo("test --logger console"));
+    }
+
+    [Test]
+    public void ToStringIncludesProcessArgumentsWhenPresent()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            processName: "dotnet",
+            processArguments: "test --logger console");
+
+        // Act
+        var result = metadata.ToString();
+
+        // Assert
+        Assert.That(result, Does.Contain("dotnet test --logger console"));
+    }
+
+    [Test]
+    public void ToStringHandlesEmptyProcessArguments()
+    {
+        // Arrange
+        var metadata = CreateTestMetadataUnderTest(
+            processName: "dotnet",
+            processArguments: "");
+
+        // Act
+        var result = metadata.ToString();
+
+        // Assert
+        Assert.That(result, Does.Contain("dotnet"));
+        Assert.That(result, Does.Not.Contain("dotnet "));
     }
 }


### PR DESCRIPTION
Introduce ProcessArguments to TestMetadata to store arguments passed to the process executing the test. Update related classes and methods to accommodate this new property, ensuring proper serialization, equality checks, and display in string representations.