### PR TITLE
Add in-memory HttpClient factory support

### DIFF
--- a/src/Xping.Sdk.Core/Clients/Http/HttpClientFactoryConfiguration.cs
+++ b/src/Xping.Sdk.Core/Clients/Http/HttpClientFactoryConfiguration.cs
@@ -34,7 +34,7 @@ public class HttpClientFactoryConfiguration : BaseConfiguration
     /// This constant is used to create or resolve a named HttpClient in the DependencyInjection service collection.
     /// </remarks>
     public const string HttpClientWithRetryPolicy = nameof(HttpClientWithRetryPolicy);
-    
+
     /// <summary>
     /// The name of the HttpClient that performs retry policies for uploading test sessions to Xping.
     /// </summary>
@@ -50,6 +50,15 @@ public class HttpClientFactoryConfiguration : BaseConfiguration
     /// This constant is used to create or resolve a named HttpClient in the DependencyInjection service collection.
     /// </remarks>
     public const string HttpClientLocationDetection = nameof(HttpClientLocationDetection);
+
+    /// <summary>
+    /// The name of the HttpClient factory configured for in memory web application scenarios.
+    /// </summary>
+    /// <remarks>
+    /// This constant is used to create or resolve a named HttpClient factory in the DependencyInjection
+    /// service collection that is specifically configured for in-memory web application use cases.
+    /// </remarks>
+    public const string HttpClientFactoryForWebApplication = nameof(HttpClientFactoryForWebApplication);
 
     #endregion Named HTTP Clients
 

--- a/src/Xping.Sdk.Core/DependencyInjection/DependencyInjectionExtension.cs
+++ b/src/Xping.Sdk.Core/DependencyInjection/DependencyInjectionExtension.cs
@@ -72,8 +72,10 @@ public static class DependencyInjectionExtension
         Func<WebApplicationFactoryClientOptions, HttpClient> createClient)
     {
         var factoryConfiguration = new HttpClientFactoryConfiguration();
-        services.TryAddTransient<IHttpClientFactory>(implementationFactory:
-            serviceProvider => new WebApplicationHttpClientFactory(createClient, factoryConfiguration));
+        services.AddKeyedTransient<IHttpClientFactory>(
+            serviceKey: HttpClientFactoryConfiguration.HttpClientFactoryForWebApplication,
+            implementationFactory: (serviceProvider, serviceKey) =>
+                new WebApplicationHttpClientFactory(createClient, factoryConfiguration));
 
         return services;
     }
@@ -184,9 +186,9 @@ public static class DependencyInjectionExtension
             .AddTransientHttpErrorPolicy(builder => builder.CircuitBreakerAsync(
                 handledEventsAllowedBeforeBreaking: factoryConfiguration.HandledEventsAllowedBeforeBreaking,
                 durationOfBreak: factoryConfiguration.DurationOfBreak));
-        
+
         services.AddHttpClient(HttpClientFactoryConfiguration.HttpClientLocationDetection);
-        
+
         services.TryAddTransient<ITestSessionBuilder, TestSessionBuilder>();
         services.TryAddTransient<ITestSessionSerializer, TestSessionSerializer>();
         services.TryAddTransient<ITestSessionUploader, TestSessionUploader>();

--- a/src/Xping.Sdk/Actions/HttpClientRequestSender.cs
+++ b/src/Xping.Sdk/Actions/HttpClientRequestSender.cs
@@ -99,8 +99,17 @@ public sealed class HttpClientRequestSender : TestComponent
 
     private static IHttpClientFactory GetHttpClientFactory(IServiceProvider serviceProvider)
     {
+        // Check if a keyed service for in-memory web application exists and use it if available
+        var keyedFactory = serviceProvider.GetKeyedService<IHttpClientFactory>(
+            HttpClientFactoryConfiguration.HttpClientFactoryForWebApplication);
+        if (keyedFactory != null)
+        {
+            return keyedFactory;
+        }
+
+        // Fallback to the default IHttpClientFactory
         return serviceProvider.GetService<IHttpClientFactory>() ??
-               throw new InvalidProgramException(Errors.HttpClientsNotFound);
+            throw new InvalidProgramException(Errors.HttpClientsNotFound);
     }
 
     private async Task AnnotateTestStepWithHttpRequest(TestContext context, HttpRequestMessage request,


### PR DESCRIPTION
Introduce support for an in-memory HttpClient factory to enhance testing scenarios. Update service registration to accommodate the new factory and ensure proper fallback mechanisms.