### PR TITLE
Refactor test components for user-friendly display names

### DIFF
--- a/src/Xping.Sdk.Core/Components/CompositeTests.cs
+++ b/src/Xping.Sdk.Core/Components/CompositeTests.cs
@@ -26,11 +26,11 @@ public abstract class CompositeTests : TestComponent, ICompositeTests
     private readonly List<ITestComponent> _components = [];
 
     /// <summary>
-    /// Initializes a new instance of the CompositeTests class with the specified name and test step type.
+    /// Initializes a new instance of the CompositeTests class with the specified description and display name.
     /// </summary>
-    /// <param name="name">The name of the composite test component.</param>
     /// <param name="description">Brief description of what the composite test component does.</param>
-    protected CompositeTests(string name, string description) : base(name, TestStepType.CompositeStep, description)
+    /// <param name="displayName">User-friendly display name for the composite test component.</param>
+    protected CompositeTests(string description, string displayName) : base(TestStepType.CompositeStep, description, displayName)
     { }
 
     /// <summary>

--- a/src/Xping.Sdk.Core/Components/ITestComponent.cs
+++ b/src/Xping.Sdk.Core/Components/ITestComponent.cs
@@ -33,6 +33,11 @@ public interface ITestComponent
     string Description { get; }
 
     /// <summary>
+    /// Gets a user-friendly display name for the test component.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
     /// This method performs the test step operation asynchronously.
     /// </summary>
     /// <param name="url">A Uri object that represents the URL of the page being validated.</param>

--- a/src/Xping.Sdk.Core/Components/Pipeline.cs
+++ b/src/Xping.Sdk.Core/Components/Pipeline.cs
@@ -16,7 +16,7 @@ public class Pipeline : CompositeTests
     /// <summary>
     /// Initializes a new instance of the Pipeline class with the specified name and components.
     /// </summary>
-    /// <param name="name">The optional name of the pipeline. If null, the StepName constant is used.</param>
+    /// <param name="name">The optional display name of the pipeline. If null, "Pipeline" is used.</param>
     /// <param name="components">The test components that make up the pipeline.</param>
     /// <remarks>
     /// The Pipeline class inherits from the CompositeTests class and represents a sequence of tests that can be 
@@ -24,7 +24,8 @@ public class Pipeline : CompositeTests
     /// </remarks>
     public Pipeline(
         string? name = null,
-        params ITestComponent[] components) : base(name ?? nameof(Pipeline), "Execute a sequence of test components as a pipeline")
+        params ITestComponent[] components) : base(
+            description: "Execute a sequence of test components as a pipeline", name ?? "Pipeline")
     {
         if (components != null)
         {

--- a/src/Xping.Sdk.Core/Components/TestComponent.cs
+++ b/src/Xping.Sdk.Core/Components/TestComponent.cs
@@ -24,14 +24,15 @@ public abstract class TestComponent : ITestComponent
     /// <summary>
     /// Initializes a new instance of the TestComponent class.
     /// </summary>
-    /// <param name="name">Name of the test component.</param>
     /// <param name="type">Type of the test component.</param>
     /// <param name="description">Brief description of what the test component does.</param>
-    protected TestComponent(string name, TestStepType type, string description)
+    /// <param name="displayName">User-friendly display name for the test component.</param>
+    protected TestComponent(TestStepType type, string description, string displayName)
     {
-        Name = name.RequireNotNullOrEmpty();
+        Name = GetType().Name;
         Type = type;
         Description = description.RequireNotNullOrEmpty();
+        DisplayName = displayName.RequireNotNullOrEmpty();
     }
 
     /// <summary>
@@ -48,6 +49,11 @@ public abstract class TestComponent : ITestComponent
     /// Gets a brief description of what the test component does.
     /// </summary>
     public string Description { get; protected set; }
+
+    /// <summary>
+    /// Gets a user-friendly display name for the test component.
+    /// </summary>
+    public string DisplayName { get; protected set; }
 
     /// <summary>
     /// This method performs the test step operation asynchronously. It is an abstract method that must be implemented 

--- a/src/Xping.Sdk.Core/Session/TestSessionBuilder.cs
+++ b/src/Xping.Sdk.Core/Session/TestSessionBuilder.cs
@@ -126,6 +126,7 @@ public class TestSessionBuilder : ITestSessionBuilder
         {
             Name = Component.Name,
             Description = Component.Description,
+            DisplayName = Component.DisplayName,
             TestComponentIteration = _componentStepCounts[Component],
             StartDate = Instrumentation.StartTime,
             Duration = Instrumentation.ElapsedTime,
@@ -166,6 +167,7 @@ public class TestSessionBuilder : ITestSessionBuilder
         {
             Name = Component.Name,
             Description = Component.Description,
+            DisplayName = Component.DisplayName,
             TestComponentIteration = _componentStepCounts[Component],
             StartDate = Instrumentation.StartTime,
             Duration = Instrumentation.ElapsedTime,
@@ -206,6 +208,7 @@ public class TestSessionBuilder : ITestSessionBuilder
         {
             Name = Component.Name,
             Description = Component.Description,
+            DisplayName = Component.DisplayName,
             TestComponentIteration = _componentStepCounts[Component],
             StartDate = Instrumentation.StartTime,
             Duration = Instrumentation.ElapsedTime,

--- a/src/Xping.Sdk.Core/Session/TestStep.cs
+++ b/src/Xping.Sdk.Core/Session/TestStep.cs
@@ -42,6 +42,14 @@ public sealed record TestStep : ISerializable
     public required string Description { get; init; }
 
     /// <summary>
+    /// Gets the display name of the test step.
+    /// </summary>
+    /// <value>
+    /// A string that provides a user-friendly display name for the test step.
+    /// </value>
+    public required string DisplayName { get; init; }
+
+    /// <summary>
     /// Gets the iteration count of the test component that created this test step.
     /// </summary>
     /// <value>
@@ -133,6 +141,7 @@ public sealed record TestStep : ISerializable
 
         _name = (string)info.GetValue(nameof(Name), typeof(string)).RequireNotNull(nameof(Name));
         Description = (string)info.GetValue(nameof(Description), typeof(string)).RequireNotNull(nameof(Description));
+        DisplayName = (string)info.GetValue(nameof(DisplayName), typeof(string)).RequireNotNull(nameof(DisplayName));
         _startDate = (DateTime)info.GetValue(nameof(StartDate), typeof(DateTime)).RequireNotNull(nameof(StartDate));
         TestComponentIteration = info.GetInt32(nameof(TestComponentIteration));
         Duration = (TimeSpan)info.GetValue(nameof(Duration), typeof(TimeSpan)).RequireNotNull(nameof(Duration));
@@ -172,6 +181,7 @@ public sealed record TestStep : ISerializable
     {
         info.AddValue(nameof(Name), Name, typeof(string));
         info.AddValue(nameof(Description), Description, typeof(string));
+        info.AddValue(nameof(DisplayName), DisplayName, typeof(string));
         info.AddValue(nameof(StartDate), StartDate, typeof(DateTime));
         info.AddValue(nameof(TestComponentIteration), TestComponentIteration, typeof(int));
         info.AddValue(nameof(Duration), Duration, typeof(TimeSpan));

--- a/src/Xping.Sdk/Actions/BrowserRequestSender.cs
+++ b/src/Xping.Sdk/Actions/BrowserRequestSender.cs
@@ -40,9 +40,9 @@ public sealed class BrowserRequestSender : TestComponent
     /// </summary>
     /// <param name="configuration">The browserClient configuration.</param>
     public BrowserRequestSender(BrowserConfiguration configuration) : base(
-        name: nameof(BrowserRequestSender),
         type: TestStepType.ActionStep,
-        description: "Navigate to target URL using headless browser")
+        description: "Navigate to target URL using headless browser",
+        displayName: "Browser Request Sender")
     {
         _configuration = configuration.RequireNotNull(nameof(configuration));
     }

--- a/src/Xping.Sdk/Actions/DnsLookup.cs
+++ b/src/Xping.Sdk/Actions/DnsLookup.cs
@@ -33,20 +33,12 @@ namespace Xping.Sdk.Actions;
 public sealed class DnsLookup : TestComponent
 {
     /// <summary>
-    /// The name of the test component that represents a DnsLookup test operation.
-    /// </summary>
-    /// <remarks>
-    /// This constant is used to register the DnsLookup class in the test framework.
-    /// </remarks>
-    public const string ComponentName = "DNS lookup";
-
-    /// <summary>
     /// Initializes a new instance of the DnsLookup class.
     /// </summary>
     public DnsLookup() : base(
-        name: ComponentName,
         type: TestStepType.ActionStep,
-        description: "Resolve domain name to IP addresses using DNS lookup")
+        description: "Resolve domain name to IP addresses using DNS lookup",
+        displayName: "DNS lookup")
     { }
 
     /// <summary>

--- a/src/Xping.Sdk/Actions/HttpClientRequestSender.cs
+++ b/src/Xping.Sdk/Actions/HttpClientRequestSender.cs
@@ -37,9 +37,9 @@ public sealed class HttpClientRequestSender : TestComponent
     /// <param name="configuration">The HttpClient configuration.</param>
     public HttpClientRequestSender(HttpClientConfiguration configuration) :
         base(
-        name: nameof(HttpClientRequestSender),
         type: TestStepType.ActionStep,
-        description: "Send HTTP request to target URL")
+        description: "Send HTTP request to target URL",
+        displayName: "HTTP Client Request Sender")
     {
         _configuration = configuration.RequireNotNull(nameof(configuration));
     }

--- a/src/Xping.Sdk/Actions/IPAddressAccessibilityCheck.cs
+++ b/src/Xping.Sdk/Actions/IPAddressAccessibilityCheck.cs
@@ -36,21 +36,13 @@ public sealed class IPAddressAccessibilityCheck : TestComponent
     private readonly PingConfiguration _configuration;
 
     /// <summary>
-    /// The name of the test component that represents a IPAddressAccessibilityCheck of tests.
-    /// </summary>
-    /// <remarks>
-    /// This constant is used to register the IPAddressAccessibilityCheck class in the test framework.
-    /// </remarks>
-    public const string StepName = "IPAddress accessibility check";
-
-    /// <summary>
-    /// Initializes new instance of th
+    /// Initializes new instance of the IPAddressAccessibilityCheck class.
     /// </summary>
     /// <param name="configuration">The ping operation configuration.</param>
     public IPAddressAccessibilityCheck(PingConfiguration configuration) : base(
-        name: StepName,
         type: TestStepType.ActionStep,
-        description: "Check accessibility of resolved IP addresses using ping")
+        description: "Check accessibility of resolved IP addresses using ping",
+        displayName: "IP Address Accessibility Check")
     {
         _configuration = configuration;
     }

--- a/src/Xping.Sdk/Validations/Content/BaseContentValidator.cs
+++ b/src/Xping.Sdk/Validations/Content/BaseContentValidator.cs
@@ -22,8 +22,8 @@ namespace Xping.Sdk.Validations.Content;
 /// The BaseContentValidator class inherits from the TestComponent class and provides a common method for decoding 
 /// HTTP content.
 /// </remarks>
-public abstract class BaseContentValidator(string name, string description) : 
-    TestComponent(name, TestStepType.ValidateStep, description)
+public abstract class BaseContentValidator(string description, string displayName) : 
+    TestComponent(TestStepType.ValidateStep, description, displayName)
 {
     /// <summary>
     /// Retrieves the HttpResponseMessage from the TestContext.

--- a/src/Xping.Sdk/Validations/Content/Html/HtmlContentValidator.cs
+++ b/src/Xping.Sdk/Validations/Content/Html/HtmlContentValidator.cs
@@ -29,14 +29,6 @@ public class HtmlContentValidator : BaseContentValidator
     private readonly Action<IHtmlContent> _validation;
 
     /// <summary>
-    /// The name of the test component that represents a StringContentValidator test operation.
-    /// </summary>
-    /// <remarks>
-    /// This constant is used to register the StringContentValidator class in the test framework.
-    /// </remarks>
-    public const string StepName = nameof(HtmlContentValidator);
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="HtmlContentValidator"/> class.
     /// </summary>
     /// <param name="validation">
@@ -44,8 +36,8 @@ public class HtmlContentValidator : BaseContentValidator
     /// </param>
     /// <exception cref="ArgumentNullException">Thrown when the validation function is null.</exception>
     public HtmlContentValidator(Action<IHtmlContent> validation) : base(
-        name: StepName,
-        description: "Validate HTML content structure and elements")
+        description: "Validate HTML content structure and elements",
+        displayName: "HTML Content Validator")
     {
         _validation = validation.RequireNotNull(nameof(validation));
     }

--- a/src/Xping.Sdk/Validations/Content/Page/PageContentValidator.cs
+++ b/src/Xping.Sdk/Validations/Content/Page/PageContentValidator.cs
@@ -31,14 +31,6 @@ public class PageContentValidator : BaseContentValidator
     private readonly Func<IPage, Task> _validation;
 
     /// <summary>
-    /// The name of the test component that represents a StringContentValidator test operation.
-    /// </summary>
-    /// <remarks>
-    /// This constant is used to register the StringContentValidator class in the test framework.
-    /// </remarks>
-    public const string StepName = nameof(PageContentValidator);
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="PageContentValidator"/> class.
     /// </summary>
     /// <param name="validation">
@@ -46,8 +38,8 @@ public class PageContentValidator : BaseContentValidator
     /// </param>
     /// <exception cref="ArgumentNullException">Thrown when the validation function is null.</exception>
     public PageContentValidator(Func<IPage, Task> validation) : base(
-        name: StepName,
-        description: "Validate page content using browser-rendered DOM")
+        description: "Validate page content using browser-rendered DOM",
+        displayName: "Page Content Validator")
     {
         _validation = validation.RequireNotNull(nameof(validation));
     }

--- a/src/Xping.Sdk/Validations/HttpResponse/HttpResponseValidator.cs
+++ b/src/Xping.Sdk/Validations/HttpResponse/HttpResponseValidator.cs
@@ -25,11 +25,6 @@ public class HttpResponseValidator : TestComponent
     private readonly Action<IHttpResponse> _validation;
 
     /// <summary>
-    /// The name of the test component that uniquely identifies a HttpResponseValidator test operation.
-    /// </summary>
-    public const string StepName = nameof(HttpResponseValidator);
-
-    /// <summary>
     /// Initializes a new instance of the HttpResponseValidator class with a specified validation action.
     /// </summary>
     /// <param name="validation">
@@ -37,9 +32,9 @@ public class HttpResponseValidator : TestComponent
     /// </param>
     /// <exception cref="ArgumentNullException">Thrown when the validation action is null.</exception>
     public HttpResponseValidator(Action<IHttpResponse> validation) : base(
-        name: StepName,
         type: TestStepType.ValidateStep,
-        description: "Validate HTTP response against custom criteria")
+        description: "Validate HTTP response against custom criteria",
+        displayName: "HTTP Response Validator")
     {
         _validation = validation.RequireNotNull(nameof(validation));
     }

--- a/tests/Xping.Sdk.Availability.UnitTests/ComponentRefactoringTests.cs
+++ b/tests/Xping.Sdk.Availability.UnitTests/ComponentRefactoringTests.cs
@@ -1,0 +1,61 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * This file is part of the Xping SDK.
+ *
+ * License: [MIT]
+ */
+
+using Xping.Sdk.Actions;
+using Xping.Sdk.Actions.Configurations;
+using Xping.Sdk.Core.Clients.Http;
+using Xping.Sdk.Validations.HttpResponse;
+
+namespace Xping.Sdk.UnitTests.Components;
+
+[TestFixture]
+internal sealed class ComponentRefactoringTests
+{
+    [Test]
+    public void DnsLookup_NameIsClassNameAndDisplayNameIsUserFriendly()
+    {
+        // Arrange & Act
+        var component = new DnsLookup();
+
+        // Assert
+        Assert.That(component.Name, Is.EqualTo(nameof(DnsLookup)));
+        Assert.That(component.DisplayName, Is.EqualTo("DNS lookup"));
+    }
+
+    [Test]
+    public void HttpClientRequestSender_NameIsClassNameAndDisplayNameIsUserFriendly()
+    {
+        // Arrange & Act
+        var component = new HttpClientRequestSender(new HttpClientConfiguration());
+
+        // Assert
+        Assert.That(component.Name, Is.EqualTo(nameof(HttpClientRequestSender)));
+        Assert.That(component.DisplayName, Is.EqualTo("HTTP Client Request Sender"));
+    }
+
+    [Test]
+    public void HttpResponseValidator_NameIsClassNameAndDisplayNameIsUserFriendly()
+    {
+        // Arrange & Act
+        var component = new HttpResponseValidator(response => { });
+
+        // Assert
+        Assert.That(component.Name, Is.EqualTo(nameof(HttpResponseValidator)));
+        Assert.That(component.DisplayName, Is.EqualTo("HTTP Response Validator"));
+    }
+
+    [Test]
+    public void IPAddressAccessibilityCheck_NameIsClassNameAndDisplayNameIsUserFriendly()
+    {
+        // Arrange & Act
+        var component = new IPAddressAccessibilityCheck(new PingConfiguration());
+
+        // Assert
+        Assert.That(component.Name, Is.EqualTo(nameof(IPAddressAccessibilityCheck)));
+        Assert.That(component.DisplayName, Is.EqualTo("IP Address Accessibility Check"));
+    }
+}

--- a/tests/Xping.Sdk.Availability.UnitTests/Helpers/HtmlContentTestsHelpers.cs
+++ b/tests/Xping.Sdk.Availability.UnitTests/Helpers/HtmlContentTestsHelpers.cs
@@ -30,6 +30,7 @@ internal static class HtmlContentTestsHelpers
             Duration = TimeSpan.FromSeconds(1),
             Name = "name",
             Description = "Test step description",
+            DisplayName = "Test Display Name",
             PropertyBag = new PropertyBag<IPropertyBagValue>(properties),
             Result = TestStepResult.Failed,
             StartDate = DateTime.UtcNow,

--- a/tests/Xping.Sdk.Core.UnitTests/Components/CompositeTestsTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Components/CompositeTestsTests.cs
@@ -13,7 +13,7 @@ namespace Xping.Sdk.UnitTests.Components;
 
 internal class CompositeTestsTests
 {
-    private class CompositeTestsUnderTest(string name = nameof(CompositeTestsUnderTest)) : CompositeTests(name, "Test composite for unit testing")
+    private class CompositeTestsUnderTest() : CompositeTests("Test composite for unit testing", "Test Composite Under Test")
     {
         public override Task HandleAsync(
             Uri url,

--- a/tests/Xping.Sdk.Core.UnitTests/Components/PipelineTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Components/PipelineTests.cs
@@ -31,20 +31,19 @@ internal class PipelineTests(IServiceProvider serviceProvider)
         var pipeline = new Pipeline(name: pipelineName);
 
         // Assert
-        Assert.That(pipeline.Name, Is.EqualTo(pipelineName));
+        Assert.That(pipeline.DisplayName, Is.EqualTo(pipelineName));
+        Assert.That(pipeline.Name, Is.EqualTo(nameof(Pipeline)));
     }
 
     [Test]
-    public void NameReturnsPipelineNameWhenNameHasNotBeenProvided()
+    public void NameReturnsClassNameWhenNameHasNotBeenProvided()
     {
-        // Arrange
-        const string pipelineName = nameof(Pipeline);
-
-        // Act
+        // Arrange & Act
         var pipeline = new Pipeline();
 
         // Assert
-        Assert.That(pipeline.Name, Is.EqualTo(pipelineName));
+        Assert.That(pipeline.Name, Is.EqualTo(nameof(Pipeline)));
+        Assert.That(pipeline.DisplayName, Is.EqualTo("Pipeline"));
     }
 
     [Test]

--- a/tests/Xping.Sdk.Core.UnitTests/Components/TestComponentTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Components/TestComponentTests.cs
@@ -22,9 +22,8 @@ public sealed class TestComponentTests(IServiceProvider serviceProvider)
     private readonly IServiceProvider _serviceProvider = serviceProvider;
 
     private sealed class TestComponentUnderTest(
-        string name = nameof(TestComponentUnderTest),
         TestStepType type = TestStepType.ActionStep,
-        Mock<ICompositeTests>? compositeMock = null) : TestComponent(name, type, "Test component for unit testing")
+        Mock<ICompositeTests>? compositeMock = null) : TestComponent(type, "Test component for unit testing", "Test Component Under Test")
     {
         public bool HandleAsyncCalled { get; private set; }
 
@@ -45,11 +44,23 @@ public sealed class TestComponentTests(IServiceProvider serviceProvider)
     }
 
     [Test]
-    public void ThrowsArgumentExceptionWhenNameIsNullOrEmpty()
+    public void NameIsSetToClassName()
     {
+        // Arrange & Act
+        var component = new TestComponentUnderTest();
+
         // Assert
-        Assert.Throws<ArgumentNullException>(() => new TestComponentUnderTest(name: null!));
-        Assert.Throws<ArgumentException>(() => new TestComponentUnderTest(name: string.Empty));
+        Assert.That(component.Name, Is.EqualTo(nameof(TestComponentUnderTest)));
+    }
+
+    [Test]
+    public void DisplayNameIsSetFromConstructor()
+    {
+        // Arrange & Act
+        var component = new TestComponentUnderTest();
+
+        // Assert
+        Assert.That(component.DisplayName, Is.EqualTo("Test Component Under Test"));
     }
 
     [Test]

--- a/tests/Xping.Sdk.Core.UnitTests/Session/Comparison/ComparerBaseTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/Comparison/ComparerBaseTests.cs
@@ -38,6 +38,7 @@ public abstract class ComparerBaseTests<TComparer> where TComparer : ITestSessio
         {
             Name = name,
             Description = "Test step description",
+            DisplayName = "Test Step Display Name",
             TestComponentIteration = 1,
             StartDate = startDate ?? DateTime.UtcNow,
             Duration = duration ?? TimeSpan.Zero,

--- a/tests/Xping.Sdk.Core.UnitTests/Session/DisplayNameIntegrationTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/DisplayNameIntegrationTests.cs
@@ -1,0 +1,116 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * This file is part of the Xping SDK.
+ *
+ * License: [MIT]
+ */
+
+using Xping.Sdk.Core.Components;
+using Xping.Sdk.Core.Session;
+
+namespace Xping.Sdk.UnitTests.Session;
+
+[TestFixture]
+internal class DisplayNameIntegrationTests
+{
+    [Test]
+    public void TestStepIncludesDisplayNameFromComponent()
+    {
+        // Arrange
+        var component = new TestComponentMock();
+        var builder = CreateSessionBuilder(component);
+
+        // Act
+        var testStep = builder.Build();
+
+        // Assert
+        Assert.That(testStep.Name, Is.EqualTo(nameof(TestComponentMock)));
+        Assert.That(testStep.DisplayName, Is.EqualTo("Test Component Mock"));
+        Assert.That(testStep.Description, Is.EqualTo("Mock test component for testing"));
+    }
+
+    [Test]
+    public void TestStepDisplayNameIsSerializedAndDeserialized()
+    {
+        // Arrange
+        var originalStep = new TestStep
+        {
+            Name = "TestName",
+            Description = "Test Description",
+            DisplayName = "Test Display Name",
+            TestComponentIteration = 1,
+            StartDate = DateTime.UtcNow,
+            Duration = TimeSpan.Zero,
+            Type = TestStepType.ActionStep,
+            Result = TestStepResult.Succeeded,
+            PropertyBag = null,
+            ErrorMessage = null
+        };
+
+        // Act - Serialize and deserialize
+        var serializer = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+        using var stream = new MemoryStream();
+        
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+        serializer.Serialize(stream, originalStep);
+        stream.Position = 0;
+        var deserializedStep = (TestStep)serializer.Deserialize(stream);
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
+
+        // Assert
+        Assert.That(deserializedStep.Name, Is.EqualTo(originalStep.Name));
+        Assert.That(deserializedStep.DisplayName, Is.EqualTo(originalStep.DisplayName));
+        Assert.That(deserializedStep.Description, Is.EqualTo(originalStep.Description));
+    }
+
+    private sealed class TestComponentMock : TestComponent
+    {
+        public TestComponentMock() : base(
+            type: TestStepType.ActionStep,
+            description: "Mock test component for testing",
+            displayName: "Test Component Mock")
+        {
+        }
+
+        public override Task HandleAsync(Uri url, TestSettings settings, TestContext context, IServiceProvider serviceProvider, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private static ITestSessionBuilder CreateSessionBuilder(ITestComponent component)
+    {
+        var builder = new TestSessionBuilder();
+        var mockInstrumentation = new MockInstrumentation();
+        
+        builder.Initiate(
+            url: new Uri("https://test.com"),
+            startTime: DateTime.UtcNow,
+            context: CreateMockContext(builder, mockInstrumentation, component),
+            uploadToken: Guid.NewGuid(),
+            metadata: new TestMetadata());
+
+        return builder;
+    }
+
+    private static TestContext CreateMockContext(ITestSessionBuilder builder, InstrumentationTimer instrumentation, ITestComponent component)
+    {
+        var pipeline = new Pipeline("Test", component);
+        var context = new TestContext(
+            sessionBuilder: builder,
+            instrumentation: instrumentation,
+            sessionUploader: Mock.Of<ITestSessionUploader>(),
+            pipeline: pipeline,
+            progress: null);
+
+        context.UpdateExecutionContext(component);
+        return context;
+    }
+
+    private sealed class MockInstrumentation : InstrumentationTimer
+    {
+        public MockInstrumentation() : base(false) { }
+        public override DateTime StartTime => DateTime.UtcNow;
+        public override TimeSpan ElapsedTime => TimeSpan.Zero;
+    }
+}

--- a/tests/Xping.Sdk.Core.UnitTests/Session/Serialization/TestSessionSerializationTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/Serialization/TestSessionSerializationTests.cs
@@ -122,6 +122,7 @@ internal class TestSessionSerializationTests
                 Duration = TimeSpan.Zero,
                 Name = "stepName",
                 Description = "Test step description",
+                DisplayName = "Step Display Name",
                 PropertyBag = null,
                 Result = TestStepResult.Succeeded,
                 StartDate = DateTime.UtcNow,
@@ -167,6 +168,7 @@ internal class TestSessionSerializationTests
             {
                 Name = "step1",
                 Description = "Test step description",
+                DisplayName = "Step Display Name",
                 TestComponentIteration = 1,
                 Duration = TimeSpan.Zero,
                 PropertyBag = new PropertyBag<IPropertyBagValue>(),
@@ -216,6 +218,7 @@ internal class TestSessionSerializationTests
             {
                 Name = "step1",
                 Description = "Test step description",
+                DisplayName = "Step Display Name",
                 TestComponentIteration = 1,
                 Duration = TimeSpan.Zero,
                 PropertyBag = new PropertyBag<IPropertyBagValue>(),
@@ -286,6 +289,7 @@ internal class TestSessionSerializationTests
             {
                 Name = "step1",
                 Description = "Test step description",
+                DisplayName = "Step Display Name",
                 TestComponentIteration = 1,
                 Duration = TimeSpan.Zero,
                 PropertyBag = new PropertyBag<IPropertyBagValue>(),

--- a/tests/Xping.Sdk.Core.UnitTests/Session/TestSessionTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/TestSessionTests.cs
@@ -33,6 +33,7 @@ public sealed class TestSessionTests
         {
             Name = name,
             Description = "Test step description",
+            DisplayName = "Test Step Display Name",
             TestComponentIteration = 1,
             StartDate = startDate ?? DateTime.UtcNow,
             Duration = duration ?? TimeSpan.Zero,

--- a/tests/Xping.Sdk.Core.UnitTests/Session/TestStepTests.cs
+++ b/tests/Xping.Sdk.Core.UnitTests/Session/TestStepTests.cs
@@ -19,6 +19,7 @@ public sealed class TestStepTests
         {
             Name = "TestStepName",
             Description = "Test step description",
+            DisplayName = "Test Step Display Name",
             TestComponentIteration = 1,
             StartDate = DateTime.UtcNow - TimeSpan.FromDays(2),
             Duration = TimeSpan.Zero,
@@ -37,6 +38,7 @@ public sealed class TestStepTests
         {
             Name = "TestStepName",
             Description = "Test step description",
+            DisplayName = "Test Step Display Name",
             TestComponentIteration = 1,
             StartDate = DateTime.Today,
             Duration = TimeSpan.Zero,
@@ -55,6 +57,7 @@ public sealed class TestStepTests
         {
             Name = null!,
             Description = "Test step description",
+            DisplayName = "Test Step Display Name",
             TestComponentIteration = 1,
             StartDate = DateTime.UtcNow,
             Duration = TimeSpan.Zero,
@@ -73,6 +76,7 @@ public sealed class TestStepTests
         {
             Name = "TestStepName",
             Description = "Test step description",
+            DisplayName = "Test Step Display Name",
             TestComponentIteration = 1,
             StartDate = DateTime.UtcNow,
             Duration = TimeSpan.Zero,
@@ -92,6 +96,7 @@ public sealed class TestStepTests
         {
             Name = "TestStepName",
             Description = "Test step description",
+            DisplayName = "Test Step Display Name",
             TestComponentIteration = 1,
             StartDate = DateTime.UtcNow,
             Duration = TimeSpan.Zero,
@@ -111,6 +116,7 @@ public sealed class TestStepTests
         {
             Name = "TestStepName",
             Description = "Test step description",
+            DisplayName = "Test Step Display Name",
             TestComponentIteration = 1,
             StartDate = DateTime.UtcNow,
             Duration = TimeSpan.Zero,
@@ -122,5 +128,28 @@ public sealed class TestStepTests
 
         // Assert
         Assert.That(testStep.ErrorMessage, Is.Null);
+    }
+
+    [Test]
+    public void DisplayNameIsCorrectlySetAndPreserved()
+    {
+        // Arrange
+        const string expectedDisplayName = "Custom Display Name";
+        var testStep = new TestStep()
+        {
+            Name = "TestStepName",
+            Description = "Test step description",
+            DisplayName = expectedDisplayName,
+            TestComponentIteration = 1,
+            StartDate = DateTime.UtcNow,
+            Duration = TimeSpan.Zero,
+            Type = TestStepType.ActionStep,
+            Result = TestStepResult.Succeeded,
+            PropertyBag = null,
+            ErrorMessage = null,
+        };
+
+        // Assert
+        Assert.That(testStep.DisplayName, Is.EqualTo(expectedDisplayName));
     }
 }

--- a/tests/Xping.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
+++ b/tests/Xping.Sdk.IntegrationTests/AvailabilityTestAgentTests.cs
@@ -76,7 +76,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
         // Assert
         Assert.Multiple(() =>
         {
-            Assert.That(session.Steps.Any(step => step.Name == DnsLookup.ComponentName), Is.True);
+            Assert.That(session.Steps.Any(step => step.Name == nameof(DnsLookup)), Is.True);
             Assert.That(session.TryGetPropertyBagValue(expectedBag, out PropertyBagValue<string[]>? ips), Is.True);
         });
     }
@@ -93,7 +93,7 @@ public class AvailabilityTestAgentTests(IServiceProvider serviceProvider)
         // Assert
         Assert.Multiple(() =>
         {
-            Assert.That(session.Steps.Any(step => step.Name == IPAddressAccessibilityCheck.StepName), Is.True);
+            Assert.That(session.Steps.Any(step => step.Name == nameof(IPAddressAccessibilityCheck)), Is.True);
             Assert.That(session.TryGetPropertyBagValue(expectedBag, out PropertyBagValue<string>? ipAddress), Is.True);
         });
     }

--- a/tests/Xping.Sdk.IntegrationTests/BrowserTestAgentTests.cs
+++ b/tests/Xping.Sdk.IntegrationTests/BrowserTestAgentTests.cs
@@ -104,7 +104,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
         // Assert
         Assert.Multiple(() =>
         {
-            Assert.That(session.Steps.Any(step => step.Name == DnsLookup.ComponentName), Is.True);
+            Assert.That(session.Steps.Any(step => step.Name == nameof(DnsLookup)), Is.True);
             Assert.That(session.TryGetPropertyBagValue(expectedBag, out PropertyBagValue<string[]>? ips), Is.True);
         });
     }
@@ -123,7 +123,7 @@ public class BrowserTestAgentTests(IServiceProvider serviceProvider)
         // Assert
         Assert.Multiple(() =>
         {
-            Assert.That(session.Steps.Any(step => step.Name == IPAddressAccessibilityCheck.StepName), Is.True);
+            Assert.That(session.Steps.Any(step => step.Name == nameof(IPAddressAccessibilityCheck)), Is.True);
             Assert.That(session.TryGetPropertyBagValue(expectedBag, out PropertyBagValue<string>? ipaddress), Is.True);
         });
     }


### PR DESCRIPTION
Introduce user-friendly display names for test components and update related tests for consistency. This enhances clarity and usability in the testing framework.