### PR TITLE
Add TryGetPropertyValue and GetPropertyValue methods to PropertyBag

### DIFF
--- a/src/Xping.Sdk.Core/Common/PropertyBag.cs
+++ b/src/Xping.Sdk.Core/Common/PropertyBag.cs
@@ -5,7 +5,6 @@
  * License: [MIT]
  */
 
-using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
 using Xping.Sdk.Core.Session.Comparison.Comparers.Internals;
 


### PR DESCRIPTION
Introduce methods for enhanced value retrieval from PropertyBag, allowing for safe attempts to get values of specified types and throwing exceptions for type mismatches or missing keys.