### PR TITLE
Update configuration and docs accordingly to implementation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ dotnet add package Xping.Sdk.NUnit    # or Xping.Sdk.XUnit / Xping.Sdk.MSTest
 ### 2. Configure with environment variables
 
 ```bash
-export XPING_API_KEY="your-api-key"
-export XPING_PROJECT_ID="your-project-id"
+export XPING_APIKEY="your-api-key"
+export XPING_PROJECTID="your-project-id"
 ```
 
 ### 3. Add tracking to your tests
@@ -166,8 +166,8 @@ Xping SDK can be configured via **environment variables**, **appsettings.json**,
 
 ```bash
 # Required
-export XPING_API_KEY="your-api-key"
-export XPING_PROJECT_ID="your-project-id"
+export XPING_APIKEY="your-api-key"
+export XPING_PROJECTID="your-project-id"
 
 # Optional
 export XPING_ENABLED="true"

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -787,7 +787,7 @@ XpingContext.Initialize(config);
 
 ```yaml
 env:
-  XPING_APIKEY: ${{ secrets.XPING_API_KEY }}
+  XPING_APIKEY: ${{ secrets.XPING_APIKEY }}
   XPING_PROJECTID: "my-app"
   XPING_ENVIRONMENT: "CI"
   XPING_ENABLED: "true"
@@ -803,7 +803,7 @@ using Xping.Sdk.Core.Configuration;
 
 // Fluent builder pattern
 var config = new XpingConfigurationBuilder()
-    .WithApiKey(Environment.GetEnvironmentVariable("XPING_API_KEY"))
+    .WithApiKey(Environment.GetEnvironmentVariable("XPING_APIKEY"))
     .WithProjectId("my-application")
     .WithBatchSize(200)
     .WithFlushInterval(TimeSpan.FromMinutes(1))

--- a/docs/getting-started/ci-cd-setup.md
+++ b/docs/getting-started/ci-cd-setup.md
@@ -37,8 +37,8 @@ Store your Xping credentials as GitHub Secrets:
 
 1. Go to **Repository Settings** → **Secrets and variables** → **Actions**
 2. Add the following secrets:
-   - `XPING_API_KEY`: Your Xping API key (from Account → Settings → API & Integration)
-   - `XPING_PROJECT_ID`: Your chosen project identifier (e.g., `"my-app"`)
+   - `XPING_APIKEY`: Your Xping API key (from Account → Settings → API & Integration)
+   - `XPING_PROJECTID`: Your chosen project identifier (e.g., `"my-app"`)
 
 ### Workflow Example
 
@@ -72,8 +72,8 @@ jobs:
       
       - name: Run tests with Xping
         env:
-          XPING__APIKEY: ${{ secrets.XPING_API_KEY }}
-          XPING__PROJECTID: ${{ secrets.XPING_PROJECT_ID }}
+          XPING__APIKEY: ${{ secrets.XPING_APIKEY }}
+          XPING__PROJECTID: ${{ secrets.XPING_PROJECTID }}
           XPING__ENABLED: true
           XPING__AUTODETECTCIENVIRONMENT: true
         run: dotnet test --no-build --configuration Release --logger "console;verbosity=detailed"
@@ -169,8 +169,8 @@ Store your Xping credentials as CI/CD Variables:
 
 1. Go to **Settings** → **CI/CD** → **Variables**
 2. Add the following variables:
-   - `XPING_API_KEY`: Your Xping API key (mark as masked)
-   - `XPING_PROJECT_ID`: Your chosen project identifier (e.g., `"my-app"`)
+   - `XPING_APIKEY`: Your Xping API key (mark as masked)
+   - `XPING_PROJECTID`: Your chosen project identifier (e.g., `"my-app"`)
 
 ### Pipeline Example (.gitlab-ci.yml)
 
@@ -205,8 +205,8 @@ test:
   script:
     - dotnet test --no-build --configuration Release --logger "console;verbosity=detailed"
   variables:
-    XPING__APIKEY: $XPING_API_KEY
-    XPING__PROJECTID: $XPING_PROJECT_ID
+    XPING__APIKEY: $XPING_APIKEY
+    XPING__PROJECTID: $XPING_PROJECTID
 ```
 
 ### Captured Metadata
@@ -296,8 +296,8 @@ Store your Xping credentials as Environment Variables:
 
 1. Go to **Project Settings** → **Environment Variables**
 2. Add the following variables:
-   - `XPING_API_KEY`: Your Xping API key
-   - `XPING_PROJECT_ID`: Your chosen project identifier (e.g., `"my-app"`)
+   - `XPING_APIKEY`: Your Xping API key
+   - `XPING_PROJECTID`: Your chosen project identifier (e.g., `"my-app"`)
 
 ### Pipeline Example (.circleci/config.yml)
 
@@ -313,8 +313,8 @@ jobs:
       - image: mcr.microsoft.com/dotnet/sdk:8.0
     
     environment:
-      XPING__APIKEY: $XPING_API_KEY
-      XPING__PROJECTID: $XPING_PROJECT_ID
+      XPING__APIKEY: $XPING_APIKEY
+      XPING__PROJECTID: $XPING_PROJECTID
       XPING__ENABLED: "true"
       XPING__AUTODETECTCIENVIRONMENT: "true"
     
@@ -358,7 +358,7 @@ Xping automatically captures:
 **✅ Do:**
 ```yaml
 env:
-  XPING__APIKEY: ${{ secrets.XPING_API_KEY }}
+  XPING__APIKEY: ${{ secrets.XPING_APIKEY }}
 ```
 
 **❌ Don't:**
@@ -543,7 +543,7 @@ Track different branches in different Xping projects:
 
 - name: Run tests
   env:
-    XPING__APIKEY: ${{ secrets.XPING_API_KEY }}
+    XPING__APIKEY: ${{ secrets.XPING_APIKEY }}
   run: dotnet test
 ```
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -383,7 +383,7 @@ Environment variables must use double underscores for nested properties:
 ❌ **Incorrect:**
 ```bash
 export XPING.APIKEY="key"           # Wrong: uses dot
-export XPING_API_KEY="key"          # Wrong: snake_case
+export XPING_APIKEY="key"          # Wrong: snake_case
 ```
 
 ✅ **Correct:**
@@ -661,8 +661,8 @@ Use CI/CD secret management:
 ```yaml
 - name: Run Tests
   env:
-    XPING__APIKEY: ${{ secrets.XPING_API_KEY }}
-    XPING__PROJECTID: ${{ secrets.XPING_PROJECT_ID }}
+    XPING__APIKEY: ${{ secrets.XPING_APIKEY }}
+    XPING__PROJECTID: ${{ secrets.XPING_PROJECTID }}
   run: dotnet test
 ```
 
@@ -682,8 +682,8 @@ test:
   script:
     - dotnet test
   variables:
-    XPING__APIKEY: $XPING_API_KEY      # From GitLab CI/CD variables
-    XPING__PROJECTID: $XPING_PROJECT_ID
+    XPING__APIKEY: $XPING_APIKEY      # From GitLab CI/CD variables
+    XPING__PROJECTID: $XPING_PROJECTID
 ```
 
 See [CI/CD Setup Guide](../getting-started/ci-cd-setup.md) for platform-specific instructions.

--- a/nuspec/README.md
+++ b/nuspec/README.md
@@ -120,8 +120,8 @@ Configure Xping SDK using `appsettings.json` or environment variables:
 ### Environment Variables (Recommended for CI/CD)
 
 ```bash
-export XPING_API_KEY="your-api-key"
-export XPING_PROJECT_ID="your-project-id"
+export XPING_APIKEY="your-api-key"
+export XPING_PROJECTID="your-project-id"
 export XPING_ENABLED="true"
 ```
 

--- a/samples/SampleApp.MSTest/SampleApp.MSTest.csproj
+++ b/samples/SampleApp.MSTest/SampleApp.MSTest.csproj
@@ -14,6 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Xping.Sdk.MSTest\Xping.Sdk.MSTest.csproj" />
   </ItemGroup>
 

--- a/samples/SampleApp.MSTest/SampleTests.cs
+++ b/samples/SampleApp.MSTest/SampleTests.cs
@@ -49,6 +49,27 @@ public class CalculatorTests : XpingTestBase
         Assert.Fail("Should not run");
     }
 
+    /// <summary>
+    /// FLAKY TEST TYPE 1: Time-based race condition.
+    /// This test fails intermittently based on timing - simulates a race condition
+    /// or timeout issue that occurs unpredictably in real-world scenarios.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Flaky")]
+    [TestCategory("RaceCondition")]
+    public async Task FlakyTest_RaceCondition_FailsIntermittently()
+    {
+        // Simulate a race condition that fails ~40% of the time
+        var delayMs = DateTime.Now.Millisecond % 100;
+        await Task.Delay(delayMs);
+
+        // This assertion fails when the delay is less than 60ms
+        // Simulates a timing-dependent operation that doesn't always complete in time
+        Assert.IsTrue(delayMs >= 60,
+            $"Race condition detected: operation completed too quickly ({delayMs}ms). " +
+            "This simulates a test that depends on timing and fails intermittently.");
+    }
+
     [DataTestMethod]
     [DataRow(2, 3, 5)]
     [DataRow(10, 5, 15)]

--- a/samples/SampleApp.MSTest/appsettings.json
+++ b/samples/SampleApp.MSTest/appsettings.json
@@ -1,0 +1,18 @@
+{
+  "Xping": {
+    "ProjectId": "sampleapp-mstest",
+    "ApiEndpoint": "https://upload.xping.io/api/v1",
+    "BatchSize": 100,
+    "FlushInterval": "00:00:30",
+    "Environment": "Local",
+    "AutoDetectCIEnvironment": true,
+    "Enabled": true,
+    "CaptureStackTraces": true,
+    "EnableCompression": true,
+    "MaxRetries": 3,
+    "RetryDelay": "00:00:02",
+    "SamplingRate": 1.0,
+    "UploadTimeout": "00:00:30",
+    "CollectNetworkMetrics": true
+  }
+}

--- a/samples/SampleApp.NUnit/SampleApp.NUnit.csproj
+++ b/samples/SampleApp.NUnit/SampleApp.NUnit.csproj
@@ -17,6 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Xping.Sdk.NUnit\Xping.Sdk.NUnit.csproj" />
   </ItemGroup>
 

--- a/samples/SampleApp.NUnit/SampleTests.cs
+++ b/samples/SampleApp.NUnit/SampleTests.cs
@@ -8,11 +8,13 @@ namespace SampleApp.NUnit;
 using global::NUnit.Framework;
 using Xping.Sdk.NUnit;
 
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+
 /// <summary>
 /// Sample tests demonstrating NUnit adapter usage with Xping SDK.
 /// </summary>
 [TestFixture]
-[XpingTrack] // Apply to entire fixture - tracks all tests in this class
+[XpingTrack] // Apply to the entire fixture-tracks all tests in this class
 public class SampleTests
 {
     [SetUp]
@@ -42,6 +44,33 @@ public class SampleTests
     public void ThrowingTestIsTracked()
     {
         throw new InvalidOperationException("This is a test exception for tracking purposes.");
+    }
+
+    /// <summary>
+    /// FLAKY TEST TYPE 2: Random/Probabilistic failure.
+    /// This test fails randomly ~30% of the time, simulating tests that depend
+    /// on non-deterministic behavior like network calls, external APIs, or random data.
+    /// </summary>
+    [Test]
+    [Category("Flaky")]
+    [Category("Random")]
+    [Description("Demonstrates a flaky test that fails randomly due to probabilistic behavior")]
+    public void FlakyTest_RandomFailure_FailsProbabilistically()
+    {
+        // Use a pseudo-random seed based on time to get different results per run
+        var seed = DateTime.Now.Millisecond + DateTime.Now.Second * 1000;
+        var random = new Random(seed);
+        // CA5394 suppressed: Random generator used intentionally to simulate non-deterministic test behavior
+        // for observability testing
+#pragma warning disable CA5394 // Do not use insecure randomness
+        var randomValue = random.Next(0, 100);
+#pragma warning restore CA5394 // Do not use insecure randomness
+
+        // Fails approximately 30% of the time
+        // Simulates unreliable external dependencies or non-deterministic operations
+        Assert.That(randomValue, Is.GreaterThan(30),
+            $"Random failure occurred (value: {randomValue}). " +
+            "This simulates a test with non-deterministic behavior like flaky network calls or database connections.");
     }
 
     [Test]
@@ -84,7 +113,7 @@ public class SampleTests
 public class MethodLevelTracking
 {
     [Test]
-    [XpingTrack] // Apply to specific method only
+    [XpingTrack] // Apply to a specific method only
     [Description("Only this test will be tracked")]
     public void TrackedTest()
     {

--- a/samples/SampleApp.NUnit/appsettings.json
+++ b/samples/SampleApp.NUnit/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Xping": {
+    "ProjectId": "sampleapp-nunit",
+    "ApiEndpoint": "https://localhost:7100/api/v1",
+    "BatchSize": 100,
+    "FlushInterval": "00:00:30",
+    "AutoDetectCIEnvironment": true,
+    "Enabled": true,
+    "CaptureStackTraces": true,
+    "EnableCompression": true,
+    "MaxRetries": 3,
+    "RetryDelay": "00:00:02",
+    "SamplingRate": 1.0,
+    "UploadTimeout": "00:00:30",
+    "CollectNetworkMetrics": true
+  }
+}

--- a/samples/SampleApp.XUnit/SampleApp.XUnit.csproj
+++ b/samples/SampleApp.XUnit/SampleApp.XUnit.csproj
@@ -15,6 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Xping.Sdk.XUnit\Xping.Sdk.XUnit.csproj" />
   </ItemGroup>
 

--- a/samples/SampleApp.XUnit/SampleTests.cs
+++ b/samples/SampleApp.XUnit/SampleTests.cs
@@ -5,7 +5,9 @@
 
 namespace SampleApp.XUnit;
 
-using global::Xunit;
+using Xunit;
+
+#pragma warning disable CA1707 // Identifiers should not contain underscores
 
 /// <summary>
 /// Sample tests demonstrating xUnit adapter usage with Xping SDK.
@@ -13,7 +15,6 @@ using global::Xunit;
 /// </summary>
 public class SampleTests
 {
-
     [Fact]
     [Trait("Category", "Integration")]
     public void PassingTestIsTracked()
@@ -33,6 +34,30 @@ public class SampleTests
     public void ThrowingTestIsTracked()
     {
         throw new InvalidOperationException("This is a test exception for tracking purposes.");
+    }
+
+    /// <summary>
+    /// FLAKY TEST TYPE 3: Environment/State-based failure.
+    /// This test fails intermittently based on system state (file system, process count, etc.).
+    /// Simulates tests that depend on machine state, available resources, or global state.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Flaky")]
+    [Trait("Category", "StateDependency")]
+    public void FlakyTest_EnvironmentState_FailsBasedOnSystemState()
+    {
+        // Simulate environment-dependent behavior using process count as proxy
+        // In real scenarios, this could be file locks, port availability, memory pressure, etc.
+        var processCount = System.Diagnostics.Process.GetProcesses().Length;
+        var isEvenSecond = DateTime.Now.Second % 2 == 0;
+
+        // Fails when both conditions are met (approximately 25% of the time)
+        // Simulates tests that depend on external system state
+        var shouldPass = processCount % 3 != 0 || !isEvenSecond;
+
+        Assert.True(shouldPass,
+            $"Environment state conflict detected (processes: {processCount}, second: {DateTime.Now.Second}). " +
+            "This simulates a test that fails due to system state like file locks, port conflicts, or resource contention.");
     }
 
     [Fact]
@@ -75,18 +100,13 @@ public class SampleTests
 
     public static TheoryData<string, int> GetTestData()
     {
-        return new TheoryData<string, int>
-        {
-            { "hello", 5 },
-            { "world", 5 },
-            { "xunit", 5 },
-        };
+        return new TheoryData<string, int> { { "hello", 5 }, { "world", 5 }, { "xunit", 5 }, };
     }
 }
 
-/// <summary>
-/// Sample tests demonstrating test collections and fixtures.
-/// </summary>
+// <summary>
+// Sample tests demonstrating test collections and fixtures.
+// </summary>
 [Collection("Sample Collection")]
 public class CollectionTests
 {

--- a/samples/SampleApp.XUnit/appsettings.json
+++ b/samples/SampleApp.XUnit/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Xping": {
+    "ProjectId": "sampleapp-xunit",
+    "ApiEndpoint": "https://localhost:7100/api/v1",
+    "BatchSize": 100,
+    "FlushInterval": "00:00:30",
+    "AutoDetectCIEnvironment": true,
+    "Enabled": false,
+    "CaptureStackTraces": true,
+    "EnableCompression": true,
+    "MaxRetries": 3,
+    "RetryDelay": "00:00:02",
+    "SamplingRate": 1.0,
+    "UploadTimeout": "00:00:30",
+    "CollectNetworkMetrics": true
+  }
+}

--- a/src/Xping.Sdk.MSTest/README.md
+++ b/src/Xping.Sdk.MSTest/README.md
@@ -85,8 +85,8 @@ The adapter uses the standard Xping configuration. Add a `"Xping"` section to yo
 - `MaxRetries` - Maximum retry attempts (default: `3`)
 
 Or use environment variables:
-- `XPING_API_KEY` (required)
-- `XPING_PROJECT_ID` (required)
+- `XPING_APIKEY` (required)
+- `XPING_PROJECTID` (required)
 - `XPING_API_ENDPOINT`
 - `XPING_ENVIRONMENT`
 

--- a/src/Xping.Sdk.NUnit/README.md
+++ b/src/Xping.Sdk.NUnit/README.md
@@ -119,8 +119,8 @@ The adapter uses the standard Xping configuration. Add a `"Xping"` section to yo
 - `MaxRetries` - Maximum retry attempts (default: `3`)
 
 Or use environment variables:
-- `XPING_API_KEY` (required)
-- `XPING_PROJECT_ID` (required)
+- `XPING_APIKEY` (required)
+- `XPING_PROJECTID` (required)
 - `XPING_API_ENDPOINT`
 - `XPING_ENVIRONMENT`
 

--- a/src/Xping.Sdk.NUnit/XpingContext.cs
+++ b/src/Xping.Sdk.NUnit/XpingContext.cs
@@ -14,7 +14,7 @@ using Core.Configuration;
 using Core.Diagnostics;
 using Core.Models;
 using Core.Upload;
-using Xping.Sdk.NUnit.Diagnostics;
+using Diagnostics;
 
 /// <summary>
 /// Global context for managing Xping SDK lifecycle in NUnit tests.
@@ -28,6 +28,7 @@ public static class XpingContext
     private static HttpClient? _httpClient;
     private static TestSession? _currentSession;
     private static ExecutionTracker? _executionTracker;
+    private static bool _configErrorsLogged;
 
     /// <summary>
     /// Gets a value indicating whether the context is initialized.
@@ -196,13 +197,14 @@ public static class XpingContext
 
         // Validate configuration and log any issues
         var errors = configuration.Validate();
-        if (errors.Count > 0)
+        if (!_configErrorsLogged && errors.Count > 0)
         {
             logger.LogError("Invalid configuration:");
             foreach (var error in errors)
             {
                 logger.LogError($"  - {error}");
             }
+            _configErrorsLogged = true;
         }
 
         // Check for common misconfigurations

--- a/src/Xping.Sdk.XUnit/README.md
+++ b/src/Xping.Sdk.XUnit/README.md
@@ -94,8 +94,8 @@ The adapter uses the standard Xping configuration. Add a `"Xping"` section to yo
 - `MaxRetries` - Maximum retry attempts (default: `3`)
 
 Or use environment variables:
-- `XPING_API_KEY` (required)
-- `XPING_PROJECT_ID` (required)
+- `XPING_APIKEY` (required)
+- `XPING_PROJECTID` (required)
 - `XPING_API_ENDPOINT`
 - `XPING_ENVIRONMENT`
 

--- a/tests/Xping.Sdk.Benchmarks/ConfigurationBenchmarks.cs
+++ b/tests/Xping.Sdk.Benchmarks/ConfigurationBenchmarks.cs
@@ -42,8 +42,8 @@ public class ConfigurationBenchmarks
         // Prepare environment variables simulation
         _envVariables = new Dictionary<string, string?>
         {
-            ["XPING_API_KEY"] = "test-api-key",
-            ["XPING_PROJECT_ID"] = "test-project-id",
+            ["XPING_APIKEY"] = "test-api-key",
+            ["XPING_PROJECTID"] = "test-project-id",
             ["XPING_ENABLED"] = "true",
             ["XPING_BATCH_SIZE"] = "100"
         };


### PR DESCRIPTION
This pull request standardizes the naming of Xping environment variables and secrets across documentation, samples, and configuration files. It also enhances the sample test projects by adding realistic examples of flaky tests and ensures that `appsettings.json` configuration files are included and copied in all sample projects.

**Environment Variable and Secret Naming Standardization**

* Updated all references to Xping API key and project ID environment variables from `XPING_API_KEY`/`XPING_PROJECT_ID` to `XPING_APIKEY`/`XPING_PROJECTID` in documentation and sample configurations for consistency and clarity. 

**Sample Project Improvements**

* Added `appsettings.json` files to all sample test projects (`MSTest`, `NUnit`, `XUnit`) with relevant Xping configuration, and updated `.csproj` files to ensure these files are copied to output directories.

**Flaky Test Demonstrations**

* Introduced new flaky test examples in each sample test project to demonstrate handling of intermittent, probabilistic, and environment-dependent test failures:
  - MSTest: Added a race condition-based flaky test.
  - NUnit: Added a random/probabilistic flaky test.
  - XUnit: Added an environment/state-based flaky test.

**Minor Documentation and Code Cleanups**

* Improved code comments and documentation clarity in sample test files and fixed minor typos.

These changes improve consistency, make setup easier for users, and provide better real-world examples for test tracking and troubleshooting.