### PR TITLE
fix: update API endpoint to remove redundant path segment and adjust docs

### DIFF
--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -19,7 +19,7 @@ Xping SDK supports multiple configuration methods with the following priority or
 
 | Setting | Type | Default | Environment Variable | Description |
 |---------|------|---------|---------------------|-------------|
-| `ApiEndpoint` | string | `https://upload.xping.io/api/v1` | `XPING_APIENDPOINT` | Xping API base URL |
+| `ApiEndpoint` | string | `https://upload.xping.io/v1` | `XPING_APIENDPOINT` | Xping API base URL |
 | `ApiKey` | string | **(required)** | `XPING_APIKEY` | Authentication API key |
 | `ProjectId` | string | **(required)** | `XPING_PROJECTID` | User-defined project identifier |
 | `BatchSize` | int | `100` | `XPING_BATCHSIZE` | Tests per upload batch |
@@ -144,7 +144,7 @@ A user-defined identifier for your project. Choose any meaningful name — Xping
 - **Character Set:** ASCII alphanumeric characters, hyphens (`-`), and underscores (`_`) only
 - **Format:** Must start with an alphanumeric character (a-z, 0-9), followed by any combination of alphanumeric, hyphens, or underscores
 - **Whitespace:** No spaces or whitespace characters allowed (including internal whitespace)
-- **Maximum Length:** 255 characters
+- **Maximum Length:** 128 characters
 - **Normalization:** Automatically converted to lowercase
 
 > **Important:** Once selected, avoid changing your ProjectId. Modifying it will create a new project in Xping, causing previously uploaded test executions to become disassociated from your current project. There is currently no automated migration path to transfer historical data between projects.

--- a/docs/guides/self-hosted-testing.md
+++ b/docs/guides/self-hosted-testing.md
@@ -269,7 +269,7 @@ After successful setup, view test results at [Xping Dashboard](https://app.xping
    - Check secret is not expired
 
 3. **Network issues**
-   - Verify `ApiEndpoint` is `https://upload.xping.io/api/v1`
+   - Verify `ApiEndpoint` is `https://upload.xping.io/v1`
    - Check GitHub Actions runner has internet access
 
 4. **Tracking not applied**
@@ -367,7 +367,7 @@ public async Task Xping_UploadsSuccessfully_WhenEnabled()
     // Arrange
     var config = new XpingConfiguration
     {
-        ApiEndpoint = "https://upload.xping.io/api/v1",
+        ApiEndpoint = "https://upload.xping.io/v1",
         ApiKey = Environment.GetEnvironmentVariable("XPING_APIKEY"),
         ProjectId = "sdk-dotnet-integration-test",
         Enabled = true

--- a/nuspec/README.md
+++ b/nuspec/README.md
@@ -110,7 +110,7 @@ Configure Xping SDK using `appsettings.json` or environment variables:
     "ApiKey": "your-api-key",
     "ProjectId": "your-project-id",
     "Enabled": true,
-    "ApiEndpoint": "https://upload.xping.io/api/v1",
+    "ApiEndpoint": "https://upload.xping.io/v1",
     "BatchSize": 100,
     "FlushInterval": "00:00:30"
   }

--- a/samples/SampleApp.MSTest/appsettings.json
+++ b/samples/SampleApp.MSTest/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Xping": {
     "ProjectId": "sampleapp-mstest",
-    "ApiEndpoint": "https://upload.xping.io/api/v1",
+    "ApiEndpoint": "https://upload.xping.io/v1",
     "BatchSize": 100,
     "FlushInterval": "00:00:30",
     "Environment": "Local",

--- a/samples/SampleApp.NUnit/appsettings.json
+++ b/samples/SampleApp.NUnit/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Xping": {
     "ProjectId": "sampleapp-nunit",
-    "ApiEndpoint": "https://upload.xping.io/api/v1",
+    "ApiEndpoint": "https://upload.xping.io/v1",
     "BatchSize": 100,
     "FlushInterval": "00:00:30",
     "AutoDetectCIEnvironment": true,

--- a/samples/SampleApp.XUnit/appsettings.json
+++ b/samples/SampleApp.XUnit/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Xping": {
     "ProjectId": "sampleapp-xunit",
-    "ApiEndpoint": "https://upload.xping.io/api/v1",
+    "ApiEndpoint": "https://upload.xping.io/v1",
     "BatchSize": 100,
     "FlushInterval": "00:00:30",
     "AutoDetectCIEnvironment": true,

--- a/src/Xping.Sdk.Core/Configuration/XpingConfiguration.cs
+++ b/src/Xping.Sdk.Core/Configuration/XpingConfiguration.cs
@@ -22,7 +22,7 @@ public sealed class XpingConfiguration
     /// <summary>
     /// Gets or sets the Xping API endpoint URL.
     /// </summary>
-    public string ApiEndpoint { get; set; } = "https://upload.xping.io/api/v1";
+    public string ApiEndpoint { get; set; } = "https://upload.xping.io/v1";
 
     /// <summary>
     /// Gets or sets the API key for authentication.

--- a/src/Xping.Sdk.MSTest/README.md
+++ b/src/Xping.Sdk.MSTest/README.md
@@ -66,7 +66,7 @@ The adapter uses the standard Xping configuration. Add a `"Xping"` section to yo
   "Xping": {
     "ApiKey": "your-api-key-here",
     "ProjectId": "your-project-id-here",
-    "ApiEndpoint": "https://upload.xping.io/api/v1",
+    "ApiEndpoint": "https://upload.xping.io/v1",
     "Environment": "Development",
     "EnableOfflineQueue": true,
     "MaxRetries": 3
@@ -79,7 +79,7 @@ The adapter uses the standard Xping configuration. Add a `"Xping"` section to yo
 - `ProjectId` - Your Xping project identifier (mandatory)
 
 **Optional Fields:**
-- `ApiEndpoint` - API server URL (default: `https://upload.xping.io/api/v1`)
+- `ApiEndpoint` - API server URL (default: `https://upload.xping.io/v1`)
 - `Environment` - Environment name (default: `Local`)
 - `EnableOfflineQueue` - Queue failed uploads for retry (default: `true`)
 - `MaxRetries` - Maximum retry attempts (default: `3`)
@@ -367,10 +367,10 @@ Check if the Xping API endpoint is accessible from your environment:
 
 ```bash
 # Test connectivity to the API endpoint
-curl -I https://upload.xping.io/api/v1/health
+curl -I https://upload.xping.io/v1/health
 
 # Or using PowerShell
-Invoke-WebRequest -Uri https://upload.xping.io/api/v1/health -Method Head
+Invoke-WebRequest -Uri https://upload.xping.io/v1/health -Method Head
 ```
 
 If the endpoint is unreachable, check:

--- a/src/Xping.Sdk.NUnit/README.md
+++ b/src/Xping.Sdk.NUnit/README.md
@@ -100,7 +100,7 @@ The adapter uses the standard Xping configuration. Add a `"Xping"` section to yo
   "Xping": {
     "ApiKey": "your-api-key-here",
     "ProjectId": "your-project-id-here",
-    "ApiEndpoint": "https://upload.xping.io/api/v1",
+    "ApiEndpoint": "https://upload.xping.io/v1",
     "Environment": "Development",
     "EnableOfflineQueue": true,
     "MaxRetries": 3
@@ -113,7 +113,7 @@ The adapter uses the standard Xping configuration. Add a `"Xping"` section to yo
 - `ProjectId` - Your Xping project identifier (mandatory)
 
 **Optional Fields:**
-- `ApiEndpoint` - API server URL (default: `https://upload.xping.io/api/v1`)
+- `ApiEndpoint` - API server URL (default: `https://upload.xping.io/v1`)
 - `Environment` - Environment name (default: `Local`)
 - `EnableOfflineQueue` - Queue failed uploads for retry (default: `true`)
 - `MaxRetries` - Maximum retry attempts (default: `3`)
@@ -260,10 +260,10 @@ Check if the Xping API endpoint is accessible from your environment:
 
 ```bash
 # Test connectivity to the API endpoint
-curl -I https://upload.xping.io/api/v1/health
+curl -I https://upload.xping.io/v1/health
 
 # Or using PowerShell
-Invoke-WebRequest -Uri https://upload.xping.io/api/v1/health -Method Head
+Invoke-WebRequest -Uri https://upload.xping.io/v1/health -Method Head
 ```
 
 If the endpoint is unreachable, check:

--- a/src/Xping.Sdk.XUnit/README.md
+++ b/src/Xping.Sdk.XUnit/README.md
@@ -75,7 +75,7 @@ The adapter uses the standard Xping configuration. Add a `"Xping"` section to yo
   "Xping": {
     "ApiKey": "your-api-key-here",
     "ProjectId": "your-project-id-here",
-    "ApiEndpoint": "https://upload.xping.io/api/v1",
+    "ApiEndpoint": "https://upload.xping.io/v1",
     "Environment": "Development",
     "EnableOfflineQueue": true,
     "MaxRetries": 3
@@ -88,7 +88,7 @@ The adapter uses the standard Xping configuration. Add a `"Xping"` section to yo
 - `ProjectId` - Your Xping project identifier (mandatory)
 
 **Optional Fields:**
-- `ApiEndpoint` - API server URL (default: `https://upload.xping.io/api/v1`)
+- `ApiEndpoint` - API server URL (default: `https://upload.xping.io/v1`)
 - `Environment` - Environment name (default: `Local`)
 - `EnableOfflineQueue` - Queue failed uploads for retry (default: `true`)
 - `MaxRetries` - Maximum retry attempts (default: `3`)
@@ -272,10 +272,10 @@ Check if the Xping API endpoint is accessible from your environment:
 
 ```bash
 # Test connectivity to the API endpoint
-curl -I https://upload.xping.io/api/v1/health
+curl -I https://upload.xping.io/v1/health
 
 # Or using PowerShell
-Invoke-WebRequest -Uri https://upload.xping.io/api/v1/health -Method Head
+Invoke-WebRequest -Uri https://upload.xping.io/v1/health -Method Head
 ```
 
 If the endpoint is unreachable, check:

--- a/tests/Xping.Sdk.Core.Tests/Configuration/XpingConfigurationBuilderTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Configuration/XpingConfigurationBuilderTests.cs
@@ -24,7 +24,7 @@ public class XpingConfigurationBuilderTests
         Assert.NotNull(config);
         Assert.Equal("test-key", config.ApiKey);
         Assert.Equal("test-project", config.ProjectId);
-        Assert.Equal("https://upload.xping.io/api/v1", config.ApiEndpoint);
+        Assert.Equal("https://upload.xping.io/v1", config.ApiEndpoint);
     }
 
     [Fact]

--- a/tests/Xping.Sdk.Core.Tests/Configuration/XpingConfigurationLoaderTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Configuration/XpingConfigurationLoaderTests.cs
@@ -27,7 +27,7 @@ public class XpingConfigurationLoaderTests
 
             // Assert
             Assert.NotNull(config);
-            Assert.Equal("https://upload.xping.io/api/v1", config.ApiEndpoint);
+            Assert.Equal("https://upload.xping.io/v1", config.ApiEndpoint);
             Assert.Equal("Local", config.Environment);
         }
         finally

--- a/tests/Xping.Sdk.Core.Tests/Configuration/XpingConfigurationTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Configuration/XpingConfigurationTests.cs
@@ -16,7 +16,7 @@ public class XpingConfigurationTests
         var config = new XpingConfiguration();
 
         // Assert
-        Assert.Equal("https://upload.xping.io/api/v1", config.ApiEndpoint);
+        Assert.Equal("https://upload.xping.io/v1", config.ApiEndpoint);
         Assert.Null(config.ApiKey);
         Assert.Null(config.ProjectId);
         Assert.Equal(100, config.BatchSize);


### PR DESCRIPTION
This pull request updates the default Xping API endpoint throughout the SDK, documentation, sample applications, and tests to use the new URL (`https://upload.xping.io/v1` instead of `https://upload.xping.io/api/v1`). Additionally, it reduces the maximum allowed length for the `ProjectId` setting from 255 to 128 characters in the documentation. These changes ensure consistency across all references and align with the latest backend requirements.

**API Endpoint Update:**

* Changed the default value of `ApiEndpoint` in the `XpingConfiguration` class to `https://upload.xping.io/v1` (`src/Xping.Sdk.Core/Configuration/XpingConfiguration.cs`).
* Updated all relevant documentation and code samples to reference the new API endpoint, including:
  - SDK configuration references and guides (`docs/configuration/configuration-reference.md`, `docs/guides/self-hosted-testing.md`, `nuspec/README.md`, `src/Xping.Sdk.MSTest/README.md`, `src/Xping.Sdk.NUnit/README.md`, `src/Xping.Sdk.XUnit/README.md`) [[1]](diffhunk://#diff-1b9d6fccb9b40066d072d02d2adb3d344cc69a3a4af094c46c05d9040923405cL22-R22) [[2]](diffhunk://#diff-e034245829a0c749529590dc18657d143456db624bd8f44ad77da03baf29e8d3L272-R272) [[3]](diffhunk://#diff-e034245829a0c749529590dc18657d143456db624bd8f44ad77da03baf29e8d3L370-R370) [[4]](diffhunk://#diff-b3edbaed411cf171ed62d5c29d5ab5910fed1219f972f8d8a70be607c4dc33a1L113-R113) [[5]](diffhunk://#diff-3551927c452fb16ae543986e89b5186fe7e44d7fbc51a483fab9cb336b44d1eeL69-R69) [[6]](diffhunk://#diff-3551927c452fb16ae543986e89b5186fe7e44d7fbc51a483fab9cb336b44d1eeL82-R82) [[7]](diffhunk://#diff-3551927c452fb16ae543986e89b5186fe7e44d7fbc51a483fab9cb336b44d1eeL370-R373) [[8]](diffhunk://#diff-1b0dd1689ab7763189b596dde899c6b88ddfd8f83ed2cd343cd0ec107e1b209aL103-R103) [[9]](diffhunk://#diff-1b0dd1689ab7763189b596dde899c6b88ddfd8f83ed2cd343cd0ec107e1b209aL116-R116) [[10]](diffhunk://#diff-1b0dd1689ab7763189b596dde899c6b88ddfd8f83ed2cd343cd0ec107e1b209aL263-R266) [[11]](diffhunk://#diff-d3697eaf1aa3df121130d3bfcea28c867303cb4be597ee3035162e70e7ec814eL78-R78) [[12]](diffhunk://#diff-d3697eaf1aa3df121130d3bfcea28c867303cb4be597ee3035162e70e7ec814eL91-R91) [[13]](diffhunk://#diff-d3697eaf1aa3df121130d3bfcea28c867303cb4be597ee3035162e70e7ec814eL275-R278).
  - Sample application configuration files (`samples/SampleApp.MSTest/appsettings.json`, `samples/SampleApp.NUnit/appsettings.json`, `samples/SampleApp.XUnit/appsettings.json`) [[1]](diffhunk://#diff-7b9f4ce4235816740660a4fe1cbb0d70aecfdad7de80e037b39d3304ab68e387L4-R4) [[2]](diffhunk://#diff-2e13a5421857d75943684a9f9018583007dbe0cca8169638d9cbbf7a115265eeL4-R4) [[3]](diffhunk://#diff-742f05fd7f7d236099178e46f8ec733750c5d4ba32a33e265954e7aad4d6d742L4-R4).
  - Integration test and unit test assertions for default endpoint values (`tests/Xping.Sdk.Core.Tests/Configuration/XpingConfigurationBuilderTests.cs`, `tests/Xping.Sdk.Core.Tests/Configuration/XpingConfigurationLoaderTests.cs`, `tests/Xping.Sdk.Core.Tests/Configuration/XpingConfigurationTests.cs`) [[1]](diffhunk://#diff-fda31cca63c558fe8771c130d796d9f5eaa85e59a03cfa4875bc18aab0650284L27-R27) [[2]](diffhunk://#diff-18b8558c7ef37fdb85c3a0c317471d36dce16e0f55e5d78bb925c7ccb28d491dL30-R30) [[3]](diffhunk://#diff-4b1e6b91650f31c9a52955cfd58a49349af283a754799ef23b4ded4796ee0ce0L19-R19).

**ProjectId Documentation Update:**

* Reduced the documented maximum length for `ProjectId` from 255 characters to 128 characters in the configuration reference (`docs/configuration/configuration-reference.md`).…documentation