### PR TITLE
Update test projects for multi-targeting support

### DIFF
--- a/tests/Xping.Sdk.Core.Tests/Xping.Sdk.Core.Tests.csproj
+++ b/tests/Xping.Sdk.Core.Tests/Xping.Sdk.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Xping.Sdk.Integration.Tests/Xping.Sdk.Integration.Tests.csproj
+++ b/tests/Xping.Sdk.Integration.Tests/Xping.Sdk.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Xping.Sdk.MSTest.Tests/Xping.Sdk.MSTest.Tests.csproj
+++ b/tests/Xping.Sdk.MSTest.Tests/Xping.Sdk.MSTest.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Xping.Sdk.NUnit.Tests/Xping.Sdk.NUnit.Tests.csproj
+++ b/tests/Xping.Sdk.NUnit.Tests/Xping.Sdk.NUnit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Xping.Sdk.XUnit.Tests/Xping.Sdk.XUnit.Tests.csproj
+++ b/tests/Xping.Sdk.XUnit.Tests/Xping.Sdk.XUnit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Modify test projects to target both net8.0 and net9.0, enhancing compatibility and flexibility.