### PR TITLE
fix: enable JSON deserialization of immutable models via init polyfill.

### DIFF
--- a/src/Xping.Sdk.Core/Models/Environments/EnvironmentInfo.cs
+++ b/src/Xping.Sdk.Core/Models/Environments/EnvironmentInfo.cs
@@ -51,41 +51,41 @@ public sealed class EnvironmentInfo
     /// <summary>
     /// Gets the name of the machine where the test was executed.
     /// </summary>
-    public string MachineName { get; private set; }
+    public string MachineName { get; init; }
 
     /// <summary>
     /// Gets the operating system information (e.g., "Windows 11", "macOS 14.0", "Ubuntu 22.04").
     /// </summary>
-    public string OperatingSystem { get; private set; }
+    public string OperatingSystem { get; init; }
 
     /// <summary>
     /// Gets the .NET runtime version (e.g., ".NET 8.0.0").
     /// </summary>
-    public string RuntimeVersion { get; private set; }
+    public string RuntimeVersion { get; init; }
 
     /// <summary>
     /// Gets the test framework name and version (e.g., ".NET").
     /// </summary>
-    public string Framework { get; private set; }
+    public string Framework { get; init; }
 
     /// <summary>
     /// Gets the environment name (e.g., "Local", "CI", "Staging", "Production").
     /// </summary>
-    public string EnvironmentName { get; private set; }
+    public string EnvironmentName { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether the test was executed in a CI/CD environment.
     /// </summary>
-    public bool IsCIEnvironment { get; private set; }
+    public bool IsCIEnvironment { get; init; }
 
     /// <summary>
     /// Gets the network reliability metrics collected during test execution.
     /// This property is only populated when a network metrics collection is enabled.
     /// </summary>
-    public NetworkMetrics? NetworkMetrics { get; private set; }
+    public NetworkMetrics? NetworkMetrics { get; init; }
 
     /// <summary>
     /// Gets the custom properties for additional environment information.
     /// </summary>
-    public IReadOnlyDictionary<string, string> CustomProperties { get; private set; }
+    public IReadOnlyDictionary<string, string> CustomProperties { get; init; }
 }

--- a/src/Xping.Sdk.Core/Models/Environments/NetworkMetrics.cs
+++ b/src/Xping.Sdk.Core/Models/Environments/NetworkMetrics.cs
@@ -40,20 +40,20 @@ public sealed class NetworkMetrics
     /// <summary>
     /// Gets the network latency in milliseconds (ping to Xping API).
     /// </summary>
-    public int? LatencyMs { get; private set; }
+    public int? LatencyMs { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether the network is available.
     /// </summary>
-    public bool? IsOnline { get; private set; }
+    public bool? IsOnline { get; init; }
 
     /// <summary>
     /// Gets the connection type (e.g., "Wi-Fi", "Ethernet", "Cellular", "Unknown").
     /// </summary>
-    public string ConnectionType { get; private set; } = UnknownConnectionType;
+    public string ConnectionType { get; init; } = UnknownConnectionType;
 
     /// <summary>
     /// Gets the packet loss percentage if measurable.
     /// </summary>
-    public int? PacketLossPercent { get; private set; }
+    public int? PacketLossPercent { get; init; }
 }

--- a/src/Xping.Sdk.Core/Models/Executions/RetryMetadata.cs
+++ b/src/Xping.Sdk.Core/Models/Executions/RetryMetadata.cs
@@ -58,7 +58,7 @@ public sealed class RetryMetadata
     /// 1 = first run (no retry), 2 = first retry, 3 = second retry, etc.
     /// This enables analysis of "pass on Nth attempt" patterns.
     /// </remarks>
-    public int AttemptNumber { get; private set; }
+    public int AttemptNumber { get; init; }
 
     /// <summary>
     /// Gets the maximum number of retries configured for this test.
@@ -67,7 +67,7 @@ public sealed class RetryMetadata
     /// This is the total number of retry attempts allowed, not including the initial attempt.
     /// For example, MaxRetries = 3 means: 1 initial attempt + 3 retry attempts = 4 total attempts.
     /// </remarks>
-    public int MaxRetries { get; private set; }
+    public int MaxRetries { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether this test passed after a retry (not on the first attempt).
@@ -76,7 +76,7 @@ public sealed class RetryMetadata
     /// False = passed on the first attempt (no retry needed)
     /// True = passed after one or more retries (indicates flakiness)
     /// </remarks>
-    public bool PassedOnRetry { get; private set; }
+    public bool PassedOnRetry { get; init; }
 
     /// <summary>
     /// Gets the configured delay between retry attempts.
@@ -85,7 +85,7 @@ public sealed class RetryMetadata
     /// This is the delay configured in the retry attribute.
     /// Actual delay may vary based on framework implementation.
     /// </remarks>
-    public TimeSpan DelayBetweenRetries { get; private set; }
+    public TimeSpan DelayBetweenRetries { get; init; }
 
     /// <summary>
     /// Gets the reason for the retry configuration.
@@ -95,7 +95,7 @@ public sealed class RetryMetadata
     /// This is typically extracted from custom retry attributes or attribute properties.
     /// May be null if not specified by the test author.
     /// </remarks>
-    public string? RetryReason { get; private set; }
+    public string? RetryReason { get; init; }
 
     /// <summary>
     /// Gets the name of the retry attribute or strategy used.
@@ -104,7 +104,7 @@ public sealed class RetryMetadata
     /// Examples: "RetryFact", "Retry", "TestRetry", "CustomRetry"
     /// Helps identify which retry mechanism is being used.
     /// </remarks>
-    public string RetryAttributeName { get; private set; }
+    public string RetryAttributeName { get; init; }
 
     /// <summary>
     /// Gets the additional retry-related metadata.
@@ -113,5 +113,5 @@ public sealed class RetryMetadata
     /// Used for framework-specific or custom retry attribute properties.
     /// Examples: retry filter types, exception types to retry on, custom conditions.
     /// </remarks>
-    public IReadOnlyDictionary<string, string> AdditionalMetadata { get; private set; }
+    public IReadOnlyDictionary<string, string> AdditionalMetadata { get; init; }
 }

--- a/src/Xping.Sdk.Core/Models/Executions/TestExecution.cs
+++ b/src/Xping.Sdk.Core/Models/Executions/TestExecution.cs
@@ -70,7 +70,7 @@ public sealed class TestExecution
     /// Gets the unique identifier for this test execution instance.
     /// This changes with each execution of the test.
     /// </summary>
-    public Guid ExecutionId { get; private set; }
+    public Guid ExecutionId { get; init; }
 
     /// <summary>
     /// Gets the stable test identity that persists across runs.
@@ -81,12 +81,12 @@ public sealed class TestExecution
     /// for the same test across different environments, machines, and runs.
     /// Use this for historical analysis and tracking test reliability.
     /// </remarks>
-    public TestIdentity Identity { get; private set; }
+    public TestIdentity Identity { get; init; }
 
     /// <summary>
     /// Gets the test metadata including categories, tags, and custom attributes.
     /// </summary>
-    public TestMetadata Metadata { get; private set; }
+    public TestMetadata Metadata { get; init; }
 
     /// <summary>
     /// Gets the execution context tracking order, parallelization, and suite state.
@@ -96,7 +96,7 @@ public sealed class TestExecution
     /// and resource contention patterns. Provides insights into test execution sequence,
     /// previous test information, and parallelization state.
     /// </remarks>
-    public TestOrchestrationRecord TestOrchestrationRecord { get; private set; }
+    public TestOrchestrationRecord TestOrchestrationRecord { get; init; }
 
     /// <summary>
     /// Gets retry metadata if the test is configured for retry.
@@ -108,47 +108,47 @@ public sealed class TestExecution
     /// Helps identify flaky tests that pass only after retry attempts and
     /// enables analysis of retry patterns and test reliability issues.
     /// </remarks>
-    public RetryMetadata? Retry { get; private set; }
+    public RetryMetadata? Retry { get; init; }
 
     /// <summary>
     /// Gets the display test name including parameters, mainly for debugging.
     /// </summary>
-    public string TestName { get; private set; }
+    public string TestName { get; init; }
 
     /// <summary>
     /// Gets the outcome of the test execution.
     /// </summary>
-    public TestOutcome Outcome { get; private set; }
+    public TestOutcome Outcome { get; init; }
 
     /// <summary>
     /// Gets the duration of the test execution.
     /// </summary>
-    public TimeSpan Duration { get; private set; }
+    public TimeSpan Duration { get; init; }
 
     /// <summary>
     /// Gets the start time of the test execution in UTC.
     /// </summary>
-    public DateTime StartTimeUtc { get; private set; }
+    public DateTime StartTimeUtc { get; init; }
 
     /// <summary>
     /// Gets the end time of the test execution in UTC.
     /// </summary>
-    public DateTime EndTimeUtc { get; private set; }
+    public DateTime EndTimeUtc { get; init; }
 
     /// <summary>
     /// Gets the exception type if the test failed due to an exception.
     /// </summary>
-    public string? ExceptionType { get; private set; }
+    public string? ExceptionType { get; init; }
 
     /// <summary>
     /// Gets the error message if the test failed.
     /// </summary>
-    public string? ErrorMessage { get; private set; }
+    public string? ErrorMessage { get; init; }
 
     /// <summary>
     /// Gets the stack trace if the test failed.
     /// </summary>
-    public string? StackTrace { get; private set; }
+    public string? StackTrace { get; init; }
 
     /// <summary>
     /// Gets a stable hash of the error message for grouping similar failures.
@@ -158,7 +158,7 @@ public sealed class TestExecution
     /// helping identify common failure patterns across test runs and environments.
     /// The hash is computed using SHA256 for stability and collision resistance.
     /// </remarks>
-    public string? ErrorMessageHash { get; private set; }
+    public string? ErrorMessageHash { get; init; }
 
     /// <summary>
     /// Gets a stable hash of the stack trace for grouping similar failures.
@@ -168,5 +168,5 @@ public sealed class TestExecution
     /// helping identify common failure locations and patterns in the codebase.
     /// The hash is computed using SHA256 for stability and collision resistance.
     /// </remarks>
-    public string? StackTraceHash { get; private set; }
+    public string? StackTraceHash { get; init; }
 }

--- a/src/Xping.Sdk.Core/Models/Executions/TestIdentity.cs
+++ b/src/Xping.Sdk.Core/Models/Executions/TestIdentity.cs
@@ -68,7 +68,7 @@ public sealed class TestIdentity
     /// Format: SHA256 hash as lowercase hex string (64 characters).
     /// Example: "a3f5e9c2d1b4a7f8e0c9d6b3a2f1e8d5c7b4a9f6e3d0c8b5a2f9e6d3c0b7a4f1"
     /// </remarks>
-    public string TestId { get; private set; }
+    public string TestId { get; init; }
 
     /// <summary>
     /// Gets the fully qualified name of the test.
@@ -78,7 +78,7 @@ public sealed class TestIdentity
     /// Example: "MyApp.Tests.CalculatorTests.Add_ReturnSum"
     /// This may change during refactoring, but TestId remains stable.
     /// </remarks>
-    public string FullyQualifiedName { get; private set; }
+    public string FullyQualifiedName { get; init; }
 
     /// <summary>
     /// Gets the assembly name where the test is defined.
@@ -86,7 +86,7 @@ public sealed class TestIdentity
     /// <remarks>
     /// Example: "MyApp.Tests"
     /// </remarks>
-    public string Assembly { get; private set; }
+    public string Assembly { get; init; }
 
     /// <summary>
     /// Gets the namespace where the test is defined.
@@ -94,7 +94,7 @@ public sealed class TestIdentity
     /// <remarks>
     /// Example: "MyApp.Tests"
     /// </remarks>
-    public string Namespace { get; private set; }
+    public string Namespace { get; init; }
 
     /// <summary>
     /// Gets the class name where the test method is defined.
@@ -102,7 +102,7 @@ public sealed class TestIdentity
     /// <remarks>
     /// Example: "CalculatorTests"
     /// </remarks>
-    public string ClassName { get; private set; }
+    public string ClassName { get; init; }
 
     /// <summary>
     /// Gets the test method name.
@@ -110,7 +110,7 @@ public sealed class TestIdentity
     /// <remarks>
     /// Example: "Add_ReturnSum"
     /// </remarks>
-    public string MethodName { get; private set; }
+    public string MethodName { get; init; }
 
     /// <summary>
     /// Gets the display name for human readability.
@@ -120,7 +120,7 @@ public sealed class TestIdentity
     /// Example: "Add_ReturnSum(a: 2, b: 3, expected: 5)"
     /// May include parameter names and values for better readability.
     /// </remarks>
-    public string DisplayName { get; private set; }
+    public string DisplayName { get; init; }
 
     /// <summary>
     /// Gets the parameter hash for parameterized tests.
@@ -133,17 +133,17 @@ public sealed class TestIdentity
     ///
     /// Format: Comma-separated string representation of parameters.
     /// </remarks>
-    public string? ParameterHash { get; private set; }
+    public string? ParameterHash { get; init; }
 
     /// <summary>
     /// Gets the source file path where the test is defined.
     /// Optional, useful for IDE navigation and debugging.
     /// </summary>
-    public string? SourceFile { get; private set; }
+    public string? SourceFile { get; init; }
 
     /// <summary>
     /// Gets the line number in the source file where the test begins.
     /// Optional, useful for IDE navigation and debugging.
     /// </summary>
-    public int? SourceLineNumber { get; private set; }
+    public int? SourceLineNumber { get; init; }
 }

--- a/src/Xping.Sdk.Core/Models/Executions/TestMetadata.cs
+++ b/src/Xping.Sdk.Core/Models/Executions/TestMetadata.cs
@@ -40,20 +40,20 @@ public sealed class TestMetadata
     /// <summary>
     /// Gets the test categories (e.g., "Integration", "Unit", "E2E").
     /// </summary>
-    public IReadOnlyList<string> Categories { get; private set; }
+    public IReadOnlyList<string> Categories { get; init; }
 
     /// <summary>
     /// Gets the test tags for filtering and organization.
     /// </summary>
-    public IReadOnlyList<string> Tags { get; private set; }
+    public IReadOnlyList<string> Tags { get; init; }
 
     /// <summary>
     /// Gets the custom attributes for additional test metadata.
     /// </summary>
-    public IReadOnlyDictionary<string, string> CustomAttributes { get; private set; }
+    public IReadOnlyDictionary<string, string> CustomAttributes { get; init; }
 
     /// <summary>
     /// Gets the test description.
     /// </summary>
-    public string? Description { get; private set; }
+    public string? Description { get; init; }
 }

--- a/src/Xping.Sdk.Core/Models/Executions/TestOrchestrationRecord.cs
+++ b/src/Xping.Sdk.Core/Models/Executions/TestOrchestrationRecord.cs
@@ -56,55 +56,55 @@ public sealed class TestOrchestrationRecord
     /// Gets the position of this test in the execution order (1-based).
     /// In parallel execution, this is the position within the thread/worker.
     /// </summary>
-    public int PositionInSuite { get; private set; }
+    public int PositionInSuite { get; init; }
 
     /// <summary>
     /// Gets the global position across all threads (the best effort in parallel scenarios).
     /// May be approximate when tests run in parallel across multiple workers.
     /// </summary>
-    public int? GlobalPosition { get; private set; }
+    public int? GlobalPosition { get; init; }
 
     /// <summary>
     /// Gets the stable Test ID of the test that executed immediately before this one.
     /// Null for the first test. In parallel execution, this is per-worker.
     /// </summary>
-    public string? PreviousTestId { get; private set; }
+    public string? PreviousTestId { get; init; }
 
     /// <summary>
     /// Gets the display name of the previous test for debugging.
     /// Null for the first test.
     /// </summary>
-    public string? PreviousTestName { get; private set; }
+    public string? PreviousTestName { get; init; }
 
     /// <summary>
     /// Gets the outcome of the previous test (Passed, Failed, Skipped, etc.).
     /// Null for the first test.
     /// </summary>
-    public TestOutcome? PreviousTestOutcome { get; private set; }
+    public TestOutcome? PreviousTestOutcome { get; init; }
 
     // Parallelization
 
     /// <summary>
     /// Gets a value indicating whether this test was executed in parallel with other tests.
     /// </summary>
-    public bool WasParallelized { get; private set; }
+    public bool WasParallelized { get; init; }
 
     /// <summary>
     /// Gets the number of tests executing concurrently at the time this test started.
     /// 1 for sequential execution.
     /// </summary>
-    public int ConcurrentTestCount { get; private set; }
+    public int ConcurrentTestCount { get; init; }
 
     /// <summary>
     /// Gets the thread ID or Worker ID executing this test.
     /// Useful for correlating tests that share the same execution thread.
     /// </summary>
-    public string ThreadId { get; private set; }
+    public string ThreadId { get; init; }
 
     /// <summary>
     /// Gets the framework-specific worker identifier (e.g., NUnit WorkerId, XUnit Collection).
     /// </summary>
-    public string WorkerId { get; private set; }
+    public string WorkerId { get; init; }
 
     // Test Suite Context
 
@@ -112,11 +112,11 @@ public sealed class TestOrchestrationRecord
     /// Gets the time elapsed since the test suite started executing.
     /// Useful for detecting "late in suite" failures.
     /// </summary>
-    public TimeSpan SuiteElapsedTime { get; private set; }
+    public TimeSpan SuiteElapsedTime { get; init; }
 
     /// <summary>
     /// Gets the optional framework-specific collection or fixture name.
     /// XUnit: Collection name, NUnit: Fixture name, MSTest: Test class name.
     /// </summary>
-    public string? CollectionName { get; private set; }
+    public string? CollectionName { get; init; }
 }

--- a/src/Xping.Sdk.Core/Models/TestSession.cs
+++ b/src/Xping.Sdk.Core/Models/TestSession.cs
@@ -48,32 +48,32 @@ public sealed class TestSession
     /// <summary>
     /// Gets the unique identifier for this test session.
     /// </summary>
-    public string SessionId { get; private set; }
+    public string SessionId { get; init; }
 
     /// <summary>
     /// Gets when the test session started (UTC).
     /// </summary>
-    public DateTime StartedAt { get; private set; }
+    public DateTime StartedAt { get; init; }
 
     /// <summary>
     /// Gets when the test session ended (UTC). Null if still running.
     /// </summary>
-    public DateTime? EndedAt { get; private set; }
+    public DateTime? EndedAt { get; init; }
 
     /// <summary>
     /// Gets the environment information for this test session.
     /// This is shared across all test executions in the session.
     /// </summary>
-    public EnvironmentInfo EnvironmentInfo { get; private set; }
+    public EnvironmentInfo EnvironmentInfo { get; init; }
 
     /// <summary>
     /// Gets the test executions in this session.
     /// </summary>
-    public IReadOnlyCollection<TestExecution> Executions { get; private set; }
+    public IReadOnlyCollection<TestExecution> Executions { get; init; }
 
     /// <summary>
     /// Gets the total number of tests expected in this session.
     /// Useful for tracking session completion progress.
     /// </summary>
-    public int? TotalTestsExpected { get; private set; }
+    public int? TotalTestsExpected { get; init; }
 }

--- a/src/Xping.Sdk.Core/Polyfills/IsExternalInit.cs
+++ b/src/Xping.Sdk.Core/Polyfills/IsExternalInit.cs
@@ -1,0 +1,17 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+#if !NET5_0_OR_GREATER
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Polyfill that enables the C# 9 'init' accessor on netstandard2.0 and .NET Framework targets.
+/// The C# compiler emits a reference to this type for every 'init' setter; the CLR only requires
+/// the type to be resolvable — it imposes no runtime behaviour of its own.
+/// </summary>
+internal static class IsExternalInit { }
+
+#endif

--- a/tests/Xping.Sdk.Core.Tests/Serialization/TestData/afbba725-d460-4b9f-88c6-a39c040e85aa.json
+++ b/tests/Xping.Sdk.Core.Tests/Serialization/TestData/afbba725-d460-4b9f-88c6-a39c040e85aa.json
@@ -1,0 +1,527 @@
+{
+  "sessionId": "dc6cdcdc-8567-439b-8a1d-d86fad27d05e",
+  "startedAt": "2026-02-18T09:23:51.513715Z",
+  "endedAt": "2026-02-18T09:23:51.991022Z",
+  "environmentInfo": {
+    "machineName": "MacBook-Pro",
+    "operatingSystem": "macOS (Darwin 25.2.0 Darwin Kernel Version 25.2.0: Tue Nov 18 21:08:48 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T8132)",
+    "runtimeVersion": ".NET 9.0.4",
+    "framework": ".NET",
+    "environmentName": "Local",
+    "isCIEnvironment": false,
+    "networkMetrics": {
+      "latencyMs": 0,
+      "isOnline": true,
+      "connectionType": "WiFi",
+      "packetLossPercent": 0
+    },
+    "customProperties": {
+      "Platform": "macOS",
+      "ProcessorArchitecture": "Arm64",
+      "ProcessorCount": "10"
+    }
+  },
+  "executions": [
+    {
+      "executionId": "408c62a6-43df-4a1a-8164-158de695f660",
+      "identity": {
+        "testId": "d6638513377582655769dbfe8907ed8f4e3ee8aaea14b08e11c262d65f508717",
+        "fullyQualifiedName": "SampleApp.XUnit.CollectionTests.TestInCollection",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "CollectionTests",
+        "methodName": "TestInCollection",
+        "displayName": "SampleApp.XUnit.CollectionTests.TestInCollection"
+      },
+      "metadata": {
+        "categories": [
+          "Integration"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:fact"
+        ],
+        "customAttributes": {},
+        "description": "SampleApp.XUnit.CollectionTests.TestInCollection"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 1,
+        "globalPosition": 1,
+        "wasParallelized": false,
+        "concurrentTestCount": 1,
+        "threadId": "16",
+        "workerId": "Sample Collection",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.CollectionTests.TestInCollection",
+      "outcome": "passed",
+      "duration": "00:00:00.0025819",
+      "startTimeUtc": "2026-02-18T09:23:51.585204Z",
+      "endTimeUtc": "2026-02-18T09:23:51.591113Z"
+    },
+    {
+      "executionId": "c70c9748-6907-408d-8026-5ef079b682ed",
+      "identity": {
+        "testId": "79ed386be79bb44fa687dd235182e4b2dbfdfffd555a8d2070370fc5c90aa70c",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "ParameterizedTestIsTracked",
+        "displayName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 5, b: 5, expected: 10)",
+        "parameterHash": "5,5,10"
+      },
+      "metadata": {
+        "categories": [
+          "Unit"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:theory"
+        ],
+        "customAttributes": {
+          "Arguments": "5, 5, 10"
+        },
+        "description": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 5, b: 5, expected: 10)"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 1,
+        "globalPosition": 2,
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 5, b: 5, expected: 10)",
+      "outcome": "passed",
+      "duration": "00:00:00.0034118",
+      "startTimeUtc": "2026-02-18T09:23:51.585242Z",
+      "endTimeUtc": "2026-02-18T09:23:51.641218Z"
+    },
+    {
+      "executionId": "8f7c9871-deea-49ad-af35-94990c7797e8",
+      "identity": {
+        "testId": "aee15aaa28e96a57ac2ff913f8486417f99bc1691e369dae840f5248c7dec358",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "ParameterizedTestIsTracked",
+        "displayName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 1, b: 2, expected: 3)",
+        "parameterHash": "1,2,3"
+      },
+      "metadata": {
+        "categories": [
+          "Unit"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:theory"
+        ],
+        "customAttributes": {
+          "Arguments": "1, 2, 3"
+        },
+        "description": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 1, b: 2, expected: 3)"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 2,
+        "globalPosition": 3,
+        "previousTestId": "79ed386be79bb44fa687dd235182e4b2dbfdfffd555a8d2070370fc5c90aa70c",
+        "previousTestName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 5, b: 5, expected: 10)",
+        "previousTestOutcome": "passed",
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 1, b: 2, expected: 3)",
+      "outcome": "passed",
+      "duration": "00:00:00.0003762",
+      "startTimeUtc": "2026-02-18T09:23:51.644507Z",
+      "endTimeUtc": "2026-02-18T09:23:51.644523Z"
+    },
+    {
+      "executionId": "696c8795-5d6e-4e67-a420-d1daf6019427",
+      "identity": {
+        "testId": "1ea5cd933741ce316e94671dbafe2fe74fbc2d6bab5617e039b6c2c21de695e6",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "ParameterizedTestIsTracked",
+        "displayName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 0, b: 0, expected: 0)",
+        "parameterHash": "0,0,0"
+      },
+      "metadata": {
+        "categories": [
+          "Unit"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:theory"
+        ],
+        "customAttributes": {
+          "Arguments": "0, 0, 0"
+        },
+        "description": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 0, b: 0, expected: 0)"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 3,
+        "globalPosition": 4,
+        "previousTestId": "aee15aaa28e96a57ac2ff913f8486417f99bc1691e369dae840f5248c7dec358",
+        "previousTestName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 1, b: 2, expected: 3)",
+        "previousTestOutcome": "passed",
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 0, b: 0, expected: 0)",
+      "outcome": "passed",
+      "duration": "00:00:00.0000094",
+      "startTimeUtc": "2026-02-18T09:23:51.645031Z",
+      "endTimeUtc": "2026-02-18T09:23:51.645035Z"
+    },
+    {
+      "executionId": "587f1821-a9e4-4ebd-8a05-5f872f30b314",
+      "identity": {
+        "testId": "0ece57fae7c2540d880ad28ed71a9daaf616e487950613fdef583f537ff9754b",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "MemberDataTestIsTracked",
+        "displayName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"hello\", expectedLength: 5)",
+        "parameterHash": "hello,5"
+      },
+      "metadata": {
+        "categories": [
+          "Unit"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:theory"
+        ],
+        "customAttributes": {
+          "Arguments": "hello, 5"
+        },
+        "description": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"hello\", expectedLength: 5)"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 4,
+        "globalPosition": 5,
+        "previousTestId": "1ea5cd933741ce316e94671dbafe2fe74fbc2d6bab5617e039b6c2c21de695e6",
+        "previousTestName": "SampleApp.XUnit.SampleTests.ParameterizedTestIsTracked(a: 0, b: 0, expected: 0)",
+        "previousTestOutcome": "passed",
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"hello\", expectedLength: 5)",
+      "outcome": "passed",
+      "duration": "00:00:00.0001219",
+      "startTimeUtc": "2026-02-18T09:23:51.645427Z",
+      "endTimeUtc": "2026-02-18T09:23:51.645436Z"
+    },
+    {
+      "executionId": "3f6562f3-a758-422a-bd4f-8af70684777a",
+      "identity": {
+        "testId": "41f1bc9bd9469185bfaba203fb0a64e70d692ceabe9261e20b3ff077ec8b5751",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "MemberDataTestIsTracked",
+        "displayName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"xunit\", expectedLength: 5)",
+        "parameterHash": "xunit,5"
+      },
+      "metadata": {
+        "categories": [
+          "Unit"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:theory"
+        ],
+        "customAttributes": {
+          "Arguments": "xunit, 5"
+        },
+        "description": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"xunit\", expectedLength: 5)"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 5,
+        "globalPosition": 6,
+        "previousTestId": "0ece57fae7c2540d880ad28ed71a9daaf616e487950613fdef583f537ff9754b",
+        "previousTestName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"hello\", expectedLength: 5)",
+        "previousTestOutcome": "passed",
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"xunit\", expectedLength: 5)",
+      "outcome": "passed",
+      "duration": "00:00:00.0001268",
+      "startTimeUtc": "2026-02-18T09:23:51.645845Z",
+      "endTimeUtc": "2026-02-18T09:23:51.64585Z"
+    },
+    {
+      "executionId": "4781b07c-b6f2-48d4-82d8-2edcbe27bbea",
+      "identity": {
+        "testId": "e7dd6fc42a0469932996e7174b1a216623b3aab128c33bc111fde282a2bddefb",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "MemberDataTestIsTracked",
+        "displayName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"world\", expectedLength: 5)",
+        "parameterHash": "world,5"
+      },
+      "metadata": {
+        "categories": [
+          "Unit"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:theory"
+        ],
+        "customAttributes": {
+          "Arguments": "world, 5"
+        },
+        "description": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"world\", expectedLength: 5)"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 6,
+        "globalPosition": 7,
+        "previousTestId": "41f1bc9bd9469185bfaba203fb0a64e70d692ceabe9261e20b3ff077ec8b5751",
+        "previousTestName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"xunit\", expectedLength: 5)",
+        "previousTestOutcome": "passed",
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"world\", expectedLength: 5)",
+      "outcome": "passed",
+      "duration": "00:00:00.0000041",
+      "startTimeUtc": "2026-02-18T09:23:51.646224Z",
+      "endTimeUtc": "2026-02-18T09:23:51.646229Z"
+    },
+    {
+      "executionId": "912df407-7692-4db1-93b8-f061361fab41",
+      "identity": {
+        "testId": "0c3a69872ca8dacd2ed19880f365e08fa9fa1b58b3d30c6a97febcbada726e11",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.AnotherPassingTest",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "AnotherPassingTest",
+        "displayName": "SampleApp.XUnit.SampleTests.AnotherPassingTest"
+      },
+      "metadata": {
+        "categories": [
+          "Unit",
+          "Fast"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:fact"
+        ],
+        "customAttributes": {},
+        "description": "SampleApp.XUnit.SampleTests.AnotherPassingTest"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 7,
+        "globalPosition": 8,
+        "previousTestId": "e7dd6fc42a0469932996e7174b1a216623b3aab128c33bc111fde282a2bddefb",
+        "previousTestName": "SampleApp.XUnit.SampleTests.MemberDataTestIsTracked(input: \"world\", expectedLength: 5)",
+        "previousTestOutcome": "passed",
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.SampleTests.AnotherPassingTest",
+      "outcome": "passed",
+      "duration": "00:00:00.0000153",
+      "startTimeUtc": "2026-02-18T09:23:51.6466Z",
+      "endTimeUtc": "2026-02-18T09:23:51.646605Z"
+    },
+    {
+      "executionId": "3ae507ed-67fa-4f16-bab5-fa63a39d8ecf",
+      "identity": {
+        "testId": "d15b809bcb63e81076b075917b64faa6cbfcbd775731505f9c0d330c3c3648ba",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.FlakyTest_EnvironmentState_FailsBasedOnSystemState",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "FlakyTest_EnvironmentState_FailsBasedOnSystemState",
+        "displayName": "SampleApp.XUnit.SampleTests.FlakyTest_EnvironmentState_FailsBasedOnSystemState"
+      },
+      "metadata": {
+        "categories": [
+          "Flaky",
+          "StateDependency"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:fact"
+        ],
+        "customAttributes": {},
+        "description": "SampleApp.XUnit.SampleTests.FlakyTest_EnvironmentState_FailsBasedOnSystemState"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 8,
+        "globalPosition": 9,
+        "previousTestId": "0c3a69872ca8dacd2ed19880f365e08fa9fa1b58b3d30c6a97febcbada726e11",
+        "previousTestName": "SampleApp.XUnit.SampleTests.AnotherPassingTest",
+        "previousTestOutcome": "passed",
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.SampleTests.FlakyTest_EnvironmentState_FailsBasedOnSystemState",
+      "outcome": "passed",
+      "duration": "00:00:00.0069005",
+      "startTimeUtc": "2026-02-18T09:23:51.646976Z",
+      "endTimeUtc": "2026-02-18T09:23:51.646981Z"
+    },
+    {
+      "executionId": "11fa27ba-641b-4e37-8bbe-71dd3b0837ac",
+      "identity": {
+        "testId": "fd2bfa3ab433df727b2f3ebb906aaf8bb090cc355a2bd030bea33a064351d368",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.ThrowingTestIsTracked",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "ThrowingTestIsTracked",
+        "displayName": "Verifies that a test which throws an exception is properly tracked"
+      },
+      "metadata": {
+        "categories": [
+          "Unit"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:fact"
+        ],
+        "customAttributes": {},
+        "description": "Verifies that a test which throws an exception is properly tracked"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 9,
+        "globalPosition": 10,
+        "previousTestId": "d15b809bcb63e81076b075917b64faa6cbfcbd775731505f9c0d330c3c3648ba",
+        "previousTestName": "SampleApp.XUnit.SampleTests.FlakyTest_EnvironmentState_FailsBasedOnSystemState",
+        "previousTestOutcome": "passed",
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "Verifies that a test which throws an exception is properly tracked",
+      "outcome": "failed",
+      "duration": "00:00:00.0002060",
+      "startTimeUtc": "2026-02-18T09:23:51.656887Z",
+      "endTimeUtc": "2026-02-18T09:23:51.656983Z",
+      "exceptionType": "System.InvalidOperationException",
+      "errorMessage": "This is a test exception for tracking purposes.",
+      "stackTrace": "   at SampleApp.XUnit.SampleTests.ThrowingTestIsTracked() in /Users/adrian/Dev/xping/sdk-dotnet/samples/SampleApp.XUnit/SampleTests.cs:line 36\n   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)\n   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)",
+      "errorMessageHash": "77a219d7d8d5578d9982bc1cc9e9df9be98c9dd1726686d92d3e8e9e12b66d10",
+      "stackTraceHash": "d6e1f793551f87cd65b5e218255a6e6dda69f57d2fd1d26fc0d2e986dae03005"
+    },
+    {
+      "executionId": "a1ffb5e2-7633-4f0c-bdaa-938f6ddddec6",
+      "identity": {
+        "testId": "86a729840a68c6751c4f92a723383d5610e8dfba35b271da26d87a416263d16c",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.SkippedTestIsTracked",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "SkippedTestIsTracked",
+        "displayName": "SampleApp.XUnit.SampleTests.SkippedTestIsTracked"
+      },
+      "metadata": {
+        "categories": [
+          "Integration"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:fact"
+        ],
+        "customAttributes": {},
+        "description": "SampleApp.XUnit.SampleTests.SkippedTestIsTracked"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 10,
+        "globalPosition": 11,
+        "previousTestId": "fd2bfa3ab433df727b2f3ebb906aaf8bb090cc355a2bd030bea33a064351d368",
+        "previousTestName": "Verifies that a test which throws an exception is properly tracked",
+        "previousTestOutcome": "failed",
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.SampleTests.SkippedTestIsTracked",
+      "outcome": "skipped",
+      "duration": "00:00:00.0000542",
+      "startTimeUtc": "2026-02-18T09:23:51.659341Z",
+      "endTimeUtc": "2026-02-18T09:23:51.659395Z",
+      "errorMessage": "Test skipped: Demonstrating skipped test tracking",
+      "errorMessageHash": "348e11642cd84c250d995bef0803bd1e52202d9d83e19a891d6cc19d452177ea"
+    },
+    {
+      "executionId": "20d9b3d7-3f4d-46bd-b96a-23eba0ec97f7",
+      "identity": {
+        "testId": "18825932f321357f3ad0c45869d0c52d5ae1c95051d8cc5aef331d1f8a66905f",
+        "fullyQualifiedName": "SampleApp.XUnit.SampleTests.PassingTestIsTracked",
+        "assembly": "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        "namespace": "SampleApp.XUnit",
+        "className": "SampleTests",
+        "methodName": "PassingTestIsTracked",
+        "displayName": "SampleApp.XUnit.SampleTests.PassingTestIsTracked"
+      },
+      "metadata": {
+        "categories": [
+          "Integration"
+        ],
+        "tags": [
+          "framework:xunit",
+          "type:fact"
+        ],
+        "customAttributes": {},
+        "description": "SampleApp.XUnit.SampleTests.PassingTestIsTracked"
+      },
+      "testOrchestrationRecord": {
+        "positionInSuite": 11,
+        "globalPosition": 12,
+        "previousTestId": "86a729840a68c6751c4f92a723383d5610e8dfba35b271da26d87a416263d16c",
+        "previousTestName": "SampleApp.XUnit.SampleTests.SkippedTestIsTracked",
+        "previousTestOutcome": "skipped",
+        "wasParallelized": true,
+        "concurrentTestCount": 2,
+        "threadId": "16",
+        "workerId": "Test collection for SampleApp.XUnit.SampleTests",
+        "suiteElapsedTime": "00:00:00"
+      },
+      "testName": "SampleApp.XUnit.SampleTests.PassingTestIsTracked",
+      "outcome": "passed",
+      "duration": "00:00:00.0000253",
+      "startTimeUtc": "2026-02-18T09:23:51.660402Z",
+      "endTimeUtc": "2026-02-18T09:23:51.660407Z"
+    }
+  ]
+}

--- a/tests/Xping.Sdk.Core.Tests/Serialization/XpingJsonDeserializerTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Serialization/XpingJsonDeserializerTests.cs
@@ -1,0 +1,386 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Xping.Sdk.Core.Extensions;
+using Xping.Sdk.Core.Models;
+using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.Core.Services.Serialization;
+
+namespace Xping.Sdk.Core.Tests.Serialization;
+
+public sealed class XpingJsonDeserializerTests
+{
+    private const string ResourceName =
+        "Xping.Sdk.Core.Tests.Serialization.TestData.afbba725-d460-4b9f-88c6-a39c040e85aa.json";
+
+    private static IXpingSerializer BuildSerializer()
+    {
+        var services = new ServiceCollection();
+        services.AddXpingSerialization();
+        return services.BuildServiceProvider().GetRequiredService<IXpingSerializer>();
+    }
+
+    private static Stream OpenResourceStream()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        return assembly.GetManifestResourceStream(ResourceName)
+               ?? throw new InvalidOperationException(
+                   $"Embedded resource '{ResourceName}' not found.");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Session-level fields
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Deserialize_SessionId_ShouldMatchExpectedValue()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        Assert.Equal("dc6cdcdc-8567-439b-8a1d-d86fad27d05e", session!.SessionId);
+    }
+
+    [Fact]
+    public async Task Deserialize_StartedAt_ShouldMatchExpectedUtcTimestamp()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var expected = DateTime.Parse("2026-02-18T09:23:51.513715Z", null,
+            System.Globalization.DateTimeStyles.RoundtripKind);
+        Assert.Equal(expected, session!.StartedAt);
+    }
+
+    [Fact]
+    public async Task Deserialize_EndedAt_ShouldMatchExpectedUtcTimestamp()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        Assert.NotNull(session!.EndedAt);
+        var expected = DateTime.Parse("2026-02-18T09:23:51.991022Z", null,
+            System.Globalization.DateTimeStyles.RoundtripKind);
+        Assert.Equal(expected, session.EndedAt);
+    }
+
+    // ---------------------------------------------------------------------------
+    // EnvironmentInfo fields
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Deserialize_EnvironmentInfo_ShouldPopulateMachineName()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        Assert.Equal("MacBook-Pro", session!.EnvironmentInfo.MachineName);
+    }
+
+    [Fact]
+    public async Task Deserialize_EnvironmentInfo_ShouldPopulateOperatingSystem()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        Assert.Contains("macOS", session!.EnvironmentInfo.OperatingSystem, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Deserialize_EnvironmentInfo_ShouldPopulateRuntimeVersion()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        Assert.Equal(".NET 9.0.4", session!.EnvironmentInfo.RuntimeVersion);
+    }
+
+    [Fact]
+    public async Task Deserialize_EnvironmentInfo_ShouldPopulateFramework()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        Assert.Equal(".NET", session!.EnvironmentInfo.Framework);
+    }
+
+    [Fact]
+    public async Task Deserialize_EnvironmentInfo_ShouldPopulateEnvironmentName()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        Assert.Equal("Local", session!.EnvironmentInfo.EnvironmentName);
+    }
+
+    [Fact]
+    public async Task Deserialize_EnvironmentInfo_IsCIEnvironment_ShouldBeFalse()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        Assert.False(session!.EnvironmentInfo.IsCIEnvironment);
+    }
+
+    [Fact]
+    public async Task Deserialize_EnvironmentInfo_NetworkMetrics_ShouldBePopulated()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var networkMetrics = session!.EnvironmentInfo.NetworkMetrics;
+        Assert.NotNull(networkMetrics);
+        Assert.Equal(0, networkMetrics!.LatencyMs);
+        Assert.True(networkMetrics.IsOnline);
+        Assert.Equal("WiFi", networkMetrics.ConnectionType);
+        Assert.Equal(0, networkMetrics.PacketLossPercent);
+    }
+
+    [Fact]
+    public async Task Deserialize_EnvironmentInfo_CustomProperties_ShouldBePopulated()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var props = session!.EnvironmentInfo.CustomProperties;
+        Assert.Equal("macOS", props["Platform"]);
+        Assert.Equal("Arm64", props["ProcessorArchitecture"]);
+        Assert.Equal("10", props["ProcessorCount"]);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Executions count and outcomes
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Deserialize_Executions_ShouldContainExpectedCount()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        Assert.Equal(12, session!.Executions.Count);
+    }
+
+    [Fact]
+    public async Task Deserialize_Executions_ShouldContainOneFailedTest()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var failed = session!.Executions.Where(e => e.Outcome == TestOutcome.Failed).ToList();
+        Assert.Single(failed);
+    }
+
+    [Fact]
+    public async Task Deserialize_Executions_ShouldContainOneSkippedTest()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var skipped = session!.Executions.Where(e => e.Outcome == TestOutcome.Skipped).ToList();
+        Assert.Single(skipped);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Individual execution fields
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Deserialize_FirstExecution_ShouldHaveCorrectExecutionId()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var first = session!.Executions.First();
+        Assert.Equal(Guid.Parse("408c62a6-43df-4a1a-8164-158de695f660"), first.ExecutionId);
+    }
+
+    [Fact]
+    public async Task Deserialize_FirstExecution_ShouldHaveCorrectTestName()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var first = session!.Executions.First();
+        Assert.Equal("SampleApp.XUnit.CollectionTests.TestInCollection", first.TestName);
+    }
+
+    [Fact]
+    public async Task Deserialize_FirstExecution_OutcomeShouldBePassed()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var first = session!.Executions.First();
+        Assert.Equal(TestOutcome.Passed, first.Outcome);
+    }
+
+    [Fact]
+    public async Task Deserialize_FailedExecution_ShouldHaveExceptionDetails()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var failed = session!.Executions.Single(e => e.Outcome == TestOutcome.Failed);
+        Assert.Equal("System.InvalidOperationException", failed.ExceptionType);
+        Assert.Equal("This is a test exception for tracking purposes.", failed.ErrorMessage);
+        Assert.NotNull(failed.StackTrace);
+        Assert.NotNull(failed.ErrorMessageHash);
+        Assert.NotNull(failed.StackTraceHash);
+    }
+
+    [Fact]
+    public async Task Deserialize_SkippedExecution_ShouldHaveSkipMessage()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var skipped = session!.Executions.Single(e => e.Outcome == TestOutcome.Skipped);
+        Assert.Equal("SampleApp.XUnit.SampleTests.SkippedTestIsTracked", skipped.TestName);
+        Assert.Equal("Test skipped: Demonstrating skipped test tracking", skipped.ErrorMessage);
+    }
+
+    // ---------------------------------------------------------------------------
+    // TestIdentity fields
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Deserialize_FirstExecution_Identity_ShouldBePopulated()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var identity = session!.Executions.First().Identity;
+        Assert.Equal("SampleApp.XUnit", identity.Namespace);
+        Assert.Equal("CollectionTests", identity.ClassName);
+        Assert.Equal("TestInCollection", identity.MethodName);
+        Assert.Equal("SampleApp.XUnit.CollectionTests.TestInCollection", identity.FullyQualifiedName);
+    }
+
+    [Fact]
+    public async Task Deserialize_ParameterizedExecution_Identity_ShouldIncludeParameterHash()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var parameterized = session!.Executions
+            .First(e => e.Identity.MethodName == "ParameterizedTestIsTracked"
+                        && e.Identity.ParameterHash == "5,5,10");
+        Assert.NotNull(parameterized.Identity.ParameterHash);
+        Assert.Equal("5,5,10", parameterized.Identity.ParameterHash);
+    }
+
+    // ---------------------------------------------------------------------------
+    // TestOrchestrationRecord fields
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Deserialize_FirstExecution_OrchestrationRecord_ShouldHaveGlobalPositionOne()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var first = session!.Executions.First();
+        Assert.Equal(1, first.TestOrchestrationRecord.GlobalPosition);
+        Assert.Equal(1, first.TestOrchestrationRecord.PositionInSuite);
+    }
+
+    [Fact]
+    public async Task Deserialize_SecondExecution_OrchestrationRecord_WasParallelized_ShouldBeTrue()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var second = session!.Executions.Skip(1).First();
+        Assert.True(second.TestOrchestrationRecord.WasParallelized);
+        Assert.Equal(2, second.TestOrchestrationRecord.ConcurrentTestCount);
+    }
+
+    [Fact]
+    public async Task Deserialize_ThirdExecution_OrchestrationRecord_ShouldHavePreviousTestInfo()
+    {
+        var serializer = BuildSerializer();
+        using var stream = OpenResourceStream();
+
+        var session = await serializer.DeserializeAsync<TestSession>(stream);
+
+        Assert.NotNull(session);
+        var third = session!.Executions.Skip(2).First();
+        Assert.NotNull(third.TestOrchestrationRecord.PreviousTestId);
+        Assert.NotNull(third.TestOrchestrationRecord.PreviousTestName);
+        Assert.Equal(TestOutcome.Passed, third.TestOrchestrationRecord.PreviousTestOutcome);
+    }
+}

--- a/tests/Xping.Sdk.Core.Tests/Xping.Sdk.Core.Tests.csproj
+++ b/tests/Xping.Sdk.Core.Tests/Xping.Sdk.Core.Tests.csproj
@@ -23,6 +23,7 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <EmbeddedResource Include="Serialization\TestData\afbba725-d460-4b9f-88c6-a39c040e85aa.json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates several model classes in the SDK to use C#'s `init` accessor instead of `private set` for their properties. This change allows these properties to be set during object initialization, improving immutability and making the models more compatible with object initialization syntax and record types.

The most important changes are grouped below by theme:

**Test Execution Models**

* All properties in `TestExecution`, `TestIdentity`, `TestMetadata`, `TestOrchestrationRecord`, and `RetryMetadata` now use `init` instead of `private set`, enabling initialization-only assignment and supporting immutability. [[1]](diffhunk://#diff-3b050e6a04967b2cabe18cc9ae6a1ecfbe13c93cb013578c8b55eb131739b014L73-R73) [[2]](diffhunk://#diff-3b050e6a04967b2cabe18cc9ae6a1ecfbe13c93cb013578c8b55eb131739b014L84-R89) [[3]](diffhunk://#diff-3b050e6a04967b2cabe18cc9ae6a1ecfbe13c93cb013578c8b55eb131739b014L99-R99) [[4]](diffhunk://#diff-3b050e6a04967b2cabe18cc9ae6a1ecfbe13c93cb013578c8b55eb131739b014L111-R151) [[5]](diffhunk://#diff-3b050e6a04967b2cabe18cc9ae6a1ecfbe13c93cb013578c8b55eb131739b014L161-R161) [[6]](diffhunk://#diff-3b050e6a04967b2cabe18cc9ae6a1ecfbe13c93cb013578c8b55eb131739b014L171-R171) [[7]](diffhunk://#diff-d525f8d50baff3bf9de4ebabba0296d54c6960966e7619169962c91d9421a651L71-R71) [[8]](diffhunk://#diff-d525f8d50baff3bf9de4ebabba0296d54c6960966e7619169962c91d9421a651L81-R113) [[9]](diffhunk://#diff-d525f8d50baff3bf9de4ebabba0296d54c6960966e7619169962c91d9421a651L123-R123) [[10]](diffhunk://#diff-d525f8d50baff3bf9de4ebabba0296d54c6960966e7619169962c91d9421a651L136-R148) [[11]](diffhunk://#diff-05f42ca2adc452d205b27e724a38e9202c02d5cbc6b6c540cf54efa3928efc48L43-R58) [[12]](diffhunk://#diff-116982b0e4daa945b0ef12aef95bf6b7103200f073120f5955a4bac2ea6f56bbL59-R121) [[13]](diffhunk://#diff-913dffac33665728f35ba92dd6ca480977be47bf109a9157250d404fc7d129a1L61-R61) [[14]](diffhunk://#diff-913dffac33665728f35ba92dd6ca480977be47bf109a9157250d404fc7d129a1L70-R70) [[15]](diffhunk://#diff-913dffac33665728f35ba92dd6ca480977be47bf109a9157250d404fc7d129a1L79-R79) [[16]](diffhunk://#diff-913dffac33665728f35ba92dd6ca480977be47bf109a9157250d404fc7d129a1L88-R88) [[17]](diffhunk://#diff-913dffac33665728f35ba92dd6ca480977be47bf109a9157250d404fc7d129a1L98-R98) [[18]](diffhunk://#diff-913dffac33665728f35ba92dd6ca480977be47bf109a9157250d404fc7d129a1L107-R107) [[19]](diffhunk://#diff-913dffac33665728f35ba92dd6ca480977be47bf109a9157250d404fc7d129a1L116-R116)

**Environment Models**

* Properties in `EnvironmentInfo` and `NetworkMetrics` are updated to use `init`, allowing for easier and more flexible initialization of environment-related data. [[1]](diffhunk://#diff-29391b63577f4f598f55a691fedbd69e7357a9ad3450c3790836899e8b717bc5L54-R90) [[2]](diffhunk://#diff-3671ca7da333b72219162f0eb4b682632e023eb8369840311aea20ccb813d1c0L43-R58)

These changes make the SDK's model classes easier to use with modern C# features and help enforce immutability, which is beneficial for thread safety and predictable object state.