### PR TITLE
feat(core): Implement silent failure with no-op services on config error

### DIFF
--- a/src/Xping.Sdk.Core/Services/Collector/Internals/NoOpTestExecutionCollector.cs
+++ b/src/Xping.Sdk.Core/Services/Collector/Internals/NoOpTestExecutionCollector.cs
@@ -1,0 +1,52 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using Xping.Sdk.Core.Models.Executions;
+
+namespace Xping.Sdk.Core.Services.Collector.Internals;
+
+/// <summary>
+/// A no-op implementation of <see cref="ITestExecutionCollector"/> used when the SDK
+/// is disabled or configuration validation fails. All operations are no-ops, allowing
+/// tests to run without observability tracking.
+/// </summary>
+internal sealed class NoOpTestExecutionCollector : ITestExecutionCollector
+{
+    /// <inheritdoc/>
+    public event EventHandler BufferFull
+    {
+        add { }
+        remove { }
+    }
+
+    /// <inheritdoc/>
+    public void RecordTest(TestExecution execution)
+    {
+        // No-op: discard the test execution
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<TestExecution> Drain()
+    {
+        return Array.Empty<TestExecution>();
+    }
+
+    /// <inheritdoc/>
+    public Task<CollectorStats> GetStatsAsync()
+    {
+        return Task.FromResult(new CollectorStats
+        {
+            TotalRecorded = 0,
+            BufferCount = 0,
+            TotalSampled = 0
+        });
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // No-op: nothing to dispose
+    }
+}

--- a/src/Xping.Sdk.Core/Services/Environment/Internals/NoOpEnvironmentDetector.cs
+++ b/src/Xping.Sdk.Core/Services/Environment/Internals/NoOpEnvironmentDetector.cs
@@ -1,0 +1,58 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using Xping.Sdk.Core.Models.Environments;
+
+namespace Xping.Sdk.Core.Services.Environment.Internals;
+
+/// <summary>
+/// A no-op implementation of <see cref="IEnvironmentDetector"/> used when the SDK
+/// is disabled or configuration validation fails. Returns minimal environment information
+/// without performing expensive detection operations.
+/// </summary>
+internal sealed class NoOpEnvironmentDetector : IEnvironmentDetector
+{
+    /// <inheritdoc/>
+    public string MachineName => System.Environment.MachineName;
+
+    /// <inheritdoc/>
+    public string OperatingSystem => System.Environment.OSVersion.ToString();
+
+    /// <inheritdoc/>
+    public string RuntimeVersion => System.Environment.Version.ToString();
+
+    /// <inheritdoc/>
+    public string Framework =>
+        System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+
+    /// <inheritdoc/>
+    public bool IsCiEnvironment => false;
+
+    /// <inheritdoc/>
+    public bool IsContainer => false;
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, string> CustomProperties =>
+        new Dictionary<string, string>();
+
+    /// <inheritdoc/>
+    public string EnvironmentName => "Local";
+
+    /// <inheritdoc/>
+    public Task<EnvironmentInfo> BuildEnvironmentInfoAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new EnvironmentInfo
+        {
+            MachineName = MachineName,
+            OperatingSystem = OperatingSystem,
+            RuntimeVersion = RuntimeVersion,
+            Framework = Framework,
+            IsCIEnvironment = IsCiEnvironment,
+            CustomProperties = CustomProperties,
+            EnvironmentName = EnvironmentName
+        });
+    }
+}

--- a/src/Xping.Sdk.Core/Services/Upload/Internals/NoOpXpingUploader.cs
+++ b/src/Xping.Sdk.Core/Services/Upload/Internals/NoOpXpingUploader.cs
@@ -1,0 +1,28 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using Xping.Sdk.Core.Models;
+
+namespace Xping.Sdk.Core.Services.Upload.Internals;
+
+/// <summary>
+/// A no-op implementation of <see cref="IXpingUploader"/> used when the SDK
+/// is disabled or configuration validation fails. All upload operations are no-ops,
+/// returning successful results without performing any network calls.
+/// </summary>
+internal sealed class NoOpXpingUploader : IXpingUploader
+{
+    /// <inheritdoc/>
+    public Task<UploadResult> UploadAsync(
+        TestSession testSession,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new UploadResult
+        {
+            Success = true,
+            TotalRecordsCount = 0
+        });
+    }
+}

--- a/src/Xping.Sdk.Core/Xping.Sdk.Core.csproj
+++ b/src/Xping.Sdk.Core/Xping.Sdk.Core.csproj
@@ -26,6 +26,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Xping.Sdk.Benchmarks</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Xping.Sdk.Core.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Xping.Sdk.MSTest/XpingTestBase.cs
+++ b/src/Xping.Sdk.MSTest/XpingTestBase.cs
@@ -29,7 +29,7 @@ public abstract class XpingTestBase
 
     // Resolved once on first XpingTestInitialize() call and reused for every cleanup on this instance.
     // The DI singletons are the same each time, so a single resolution per instance is enough.
-    private XpingBaseServices? _services;
+    private XpingBaseServices _services = null!;
 
     /// <summary>
     /// Gets or sets the test context which provides information about and functionality for the current test run.
@@ -82,7 +82,7 @@ public abstract class XpingTestBase
 
         try
         {
-            var execution = CreateTestExecution(_services!, TestContext, _startTime, endTime, duration, threadId, className);
+            var execution = CreateTestExecution(_services, TestContext, _startTime, endTime, duration, threadId, className);
             XpingContext.RecordTest(execution);
         }
         catch

--- a/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
+++ b/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
@@ -35,7 +35,7 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
     // Resolved once in BeforeTest() and reused for every AfterTest() on this attribute instance.
     // The attribute can be applied at assembly, class, or method scope; in all cases the same
     // DI singletons are returned each time, so a single resolution per instance is enough.
-    private XpingAttributeServices? _services;
+    private XpingAttributeServices _services = null!;
 
     /// <summary>
     /// Gets the action targets (Test level).
@@ -121,7 +121,7 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
             var workerId = TestContext.CurrentContext.WorkerId;
             var fixtureName = test.TypeInfo?.FullName ?? test.ClassName;
 
-            var execution = CreateTestExecution(_services!, test, startTime, endTime, duration, workerId, fixtureName);
+            var execution = CreateTestExecution(_services, test, startTime, endTime, duration, workerId, fixtureName);
             XpingContext.RecordTest(execution);
         }
         catch

--- a/tests/Xping.Sdk.Core.Tests/Services/Collector/NoOpTestExecutionCollectorTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Services/Collector/NoOpTestExecutionCollectorTests.cs
@@ -1,0 +1,106 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using Xping.Sdk.Core.Models.Builders;
+using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.Core.Services.Collector.Internals;
+
+namespace Xping.Sdk.Core.Tests.Services.Collector;
+
+public sealed class NoOpTestExecutionCollectorTests
+{
+    // ---------------------------------------------------------------------------
+    // RecordTest
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void RecordTest_WithValidExecution_DoesNotThrow()
+    {
+        // Arrange
+        using var collector = new NoOpTestExecutionCollector();
+        var execution = new TestExecutionBuilder()
+            .WithTestName("Test")
+            .WithOutcome(TestOutcome.Passed)
+            .Build();
+
+        // Act & Assert
+        var ex = Record.Exception(() => collector.RecordTest(execution));
+        Assert.Null(ex);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Drain
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Drain_AfterRecordingExecutions_ReturnsEmptyList()
+    {
+        // Arrange
+        using var collector = new NoOpTestExecutionCollector();
+        collector.RecordTest(new TestExecutionBuilder().WithTestName("T1").WithOutcome(TestOutcome.Passed).Build());
+        collector.RecordTest(new TestExecutionBuilder().WithTestName("T2").WithOutcome(TestOutcome.Failed).Build());
+
+        // Act
+        var result = collector.Drain();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    // ---------------------------------------------------------------------------
+    // GetStatsAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetStatsAsync_ReturnsZeroStats()
+    {
+        // Arrange
+        using var collector = new NoOpTestExecutionCollector();
+        collector.RecordTest(new TestExecutionBuilder().WithTestName("T1").WithOutcome(TestOutcome.Passed).Build());
+
+        // Act
+        var stats = await collector.GetStatsAsync();
+
+        // Assert
+        Assert.Equal(0, stats.TotalRecorded);
+        Assert.Equal(0, stats.BufferCount);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Dispose
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void Dispose_CalledMultipleTimes_DoesNotThrow()
+    {
+        // Arrange
+        var collector = new NoOpTestExecutionCollector();
+        collector.Dispose();
+
+        // Act & Assert — second call must not throw
+        var ex = Record.Exception(collector.Dispose);
+        Assert.Null(ex);
+    }
+
+    // ---------------------------------------------------------------------------
+    // BufferFull event
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void BufferFull_AddAndRemoveHandler_DoesNotThrow()
+    {
+        // Arrange
+        using var collector = new NoOpTestExecutionCollector();
+        EventHandler handler = (_, _) => { };
+
+        // Act & Assert — subscription and un-subscription must be no-ops safe
+        var ex = Record.Exception(() =>
+        {
+            collector.BufferFull += handler;
+            collector.BufferFull -= handler;
+        });
+        Assert.Null(ex);
+    }
+}

--- a/tests/Xping.Sdk.Core.Tests/Services/Environment/NoOpEnvironmentDetectorTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Services/Environment/NoOpEnvironmentDetectorTests.cs
@@ -1,0 +1,117 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using Xping.Sdk.Core.Services.Environment.Internals;
+
+namespace Xping.Sdk.Core.Tests.Services.Environment;
+
+public sealed class NoOpEnvironmentDetectorTests
+{
+    // ---------------------------------------------------------------------------
+    // Individual properties
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void IsCiEnvironment_ReturnsFalse()
+    {
+        var detector = new NoOpEnvironmentDetector();
+        Assert.False(detector.IsCiEnvironment);
+    }
+
+    [Fact]
+    public void IsContainer_ReturnsFalse()
+    {
+        var detector = new NoOpEnvironmentDetector();
+        Assert.False(detector.IsContainer);
+    }
+
+    [Fact]
+    public void EnvironmentName_ReturnsLocal()
+    {
+        var detector = new NoOpEnvironmentDetector();
+        Assert.Equal("Local", detector.EnvironmentName);
+    }
+
+    [Fact]
+    public void MachineName_ReturnsNonEmpty()
+    {
+        var detector = new NoOpEnvironmentDetector();
+        Assert.False(string.IsNullOrWhiteSpace(detector.MachineName));
+    }
+
+    [Fact]
+    public void OperatingSystem_ReturnsNonEmpty()
+    {
+        var detector = new NoOpEnvironmentDetector();
+        Assert.False(string.IsNullOrWhiteSpace(detector.OperatingSystem));
+    }
+
+    [Fact]
+    public void RuntimeVersion_ReturnsNonEmpty()
+    {
+        var detector = new NoOpEnvironmentDetector();
+        Assert.False(string.IsNullOrWhiteSpace(detector.RuntimeVersion));
+    }
+
+    [Fact]
+    public void Framework_ReturnsNonEmpty()
+    {
+        var detector = new NoOpEnvironmentDetector();
+        Assert.False(string.IsNullOrWhiteSpace(detector.Framework));
+    }
+
+    [Fact]
+    public void CustomProperties_ReturnsEmptyDictionary()
+    {
+        var detector = new NoOpEnvironmentDetector();
+        Assert.Empty(detector.CustomProperties);
+    }
+
+    // ---------------------------------------------------------------------------
+    // BuildEnvironmentInfoAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task BuildEnvironmentInfoAsync_DoesNotThrow()
+    {
+        // Arrange
+        var detector = new NoOpEnvironmentDetector();
+
+        // Act & Assert
+        var ex = await Record.ExceptionAsync(() => detector.BuildEnvironmentInfoAsync());
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public async Task BuildEnvironmentInfoAsync_ReturnsInfoConsistentWithProperties()
+    {
+        // Arrange
+        var detector = new NoOpEnvironmentDetector();
+
+        // Act
+        var info = await detector.BuildEnvironmentInfoAsync();
+
+        // Assert
+        Assert.Equal(detector.MachineName, info.MachineName);
+        Assert.Equal(detector.OperatingSystem, info.OperatingSystem);
+        Assert.Equal(detector.RuntimeVersion, info.RuntimeVersion);
+        Assert.Equal(detector.Framework, info.Framework);
+        Assert.Equal(detector.IsCiEnvironment, info.IsCIEnvironment);
+        Assert.Equal(detector.EnvironmentName, info.EnvironmentName);
+    }
+
+    [Fact]
+    public async Task BuildEnvironmentInfoAsync_WithCancelledToken_DoesNotThrow()
+    {
+        // Arrange
+        var detector = new NoOpEnvironmentDetector();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act & Assert — no-op never observes the cancellation token
+        var ex = await Record.ExceptionAsync(() => detector.BuildEnvironmentInfoAsync(cts.Token));
+        Assert.Null(ex);
+    }
+}

--- a/tests/Xping.Sdk.Core.Tests/Services/Upload/NoOpXpingUploaderTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Services/Upload/NoOpXpingUploaderTests.cs
@@ -1,0 +1,67 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using Xping.Sdk.Core.Models;
+using Xping.Sdk.Core.Services.Upload.Internals;
+
+namespace Xping.Sdk.Core.Tests.Services.Upload;
+
+public sealed class NoOpXpingUploaderTests
+{
+    // ---------------------------------------------------------------------------
+    // UploadAsync
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task UploadAsync_WithValidSession_ReturnsSuccess()
+    {
+        // Arrange
+        var uploader = new NoOpXpingUploader();
+        var session = new TestSession();
+
+        // Act
+        var result = await uploader.UploadAsync(session);
+
+        // Assert
+        Assert.True(result.Success);
+    }
+
+    [Fact]
+    public async Task UploadAsync_ReturnsZeroRecordsCount()
+    {
+        // Arrange
+        var uploader = new NoOpXpingUploader();
+
+        // Act
+        var result = await uploader.UploadAsync(new TestSession());
+
+        // Assert
+        Assert.Equal(0, result.TotalRecordsCount);
+    }
+
+    [Fact]
+    public async Task UploadAsync_WithCancelledToken_DoesNotThrow()
+    {
+        // Arrange
+        var uploader = new NoOpXpingUploader();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act & Assert — no-op should not observe the cancellation token
+        var ex = await Record.ExceptionAsync(() => uploader.UploadAsync(new TestSession(), cts.Token));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public async Task UploadAsync_WithNullSession_DoesNotThrow()
+    {
+        // Arrange
+        var uploader = new NoOpXpingUploader();
+
+        // Act & Assert — no-op never inspects the session
+        var ex = await Record.ExceptionAsync(() => uploader.UploadAsync(null!));
+        Assert.Null(ex);
+    }
+}


### PR DESCRIPTION
This pull request introduces a robust mechanism for handling SDK initialization failures and disabled states by adding no-op implementations for core services, improving error handling in the orchestrator, and updating test and framework code to ensure consistent behavior. When the SDK is disabled or configuration validation fails, the orchestrator now switches to no-op services, allowing tests to run without observability tracking while avoiding exceptions. Additionally, the pull request improves testability and code clarity across the SDK and test frameworks.

### No-op service implementations for disabled/unhealthy SDK

* Added `NoOpTestExecutionCollector`, `NoOpEnvironmentDetector`, and `NoOpXpingUploader` classes, each providing no-op implementations of their respective interfaces. These are used when the SDK is disabled or configuration validation fails, ensuring all operations are safe no-ops. (`src/Xping.Sdk.Core/Services/Collector/Internals/NoOpTestExecutionCollector.cs` [[1]](diffhunk://#diff-d480ad088b6dbb2c93bf03691cb3902c74295613ffd6f0d163347660c59a4f69R1-R52) `src/Xping.Sdk.Core/Services/Environment/Internals/NoOpEnvironmentDetector.cs` [[2]](diffhunk://#diff-ea21bd4fb4b226ec0086ffb10339c6f801226fe280d775a66ad38f7b192410feR1-R58) `src/Xping.Sdk.Core/Services/Upload/Internals/NoOpXpingUploader.cs` [[3]](diffhunk://#diff-8ed4696fa801a39ff4c0e55edbc3df573cde6cfe75101fedcb7da4d9cb180766R1-R28)

### Orchestrator error handling and healthy state tracking

* Updated `XpingContextOrchestrator` to track SDK health via `_isHealthy` and switch to no-op services when configuration validation fails or other exceptions occur during initialization. Initialization logs are improved to indicate disabled state, and flush operations are short-circuited when unhealthy. (`src/Xping.Sdk.Core/XpingContextOrchestrator.cs` [[1]](diffhunk://#diff-de0491960f82951fc7b18a1ef1d4b2c63b9e62af4425b679277ac3f4b12a1d75R49) [[2]](diffhunk://#diff-de0491960f82951fc7b18a1ef1d4b2c63b9e62af4425b679277ac3f4b12a1d75R59-R64) [[3]](diffhunk://#diff-de0491960f82951fc7b18a1ef1d4b2c63b9e62af4425b679277ac3f4b12a1d75L78-R105) [[4]](diffhunk://#diff-de0491960f82951fc7b18a1ef1d4b2c63b9e62af4425b679277ac3f4b12a1d75L117-R155) [[5]](diffhunk://#diff-de0491960f82951fc7b18a1ef1d4b2c63b9e62af4425b679277ac3f4b12a1d75R166-R169)

### Test and framework code improvements for service initialization

* Refactored MSTest (`XpingTestBase`), NUnit (`XpingTrackAttribute`), and xUnit (`XpingTestFramework`) classes to use non-nullable service fields and remove unnecessary null-forgiving operators, ensuring reliable service access regardless of SDK health. (`src/Xping.Sdk.MSTest/XpingTestBase.cs` [[1]](diffhunk://#diff-ad3b678b9390d5a67f90bee43bf83fe0f6dc9f8e78716064f52cc62a634167d0L32-R32) [[2]](diffhunk://#diff-ad3b678b9390d5a67f90bee43bf83fe0f6dc9f8e78716064f52cc62a634167d0L85-R85); `src/Xping.Sdk.NUnit/XpingTrackAttribute.cs` [[3]](diffhunk://#diff-e2241fbf6c8f6dffd4843d380a310a4fac636ae8e25a8cda2c9a245375a3d12bL38-R38) [[4]](diffhunk://#diff-e2241fbf6c8f6dffd4843d380a310a4fac636ae8e25a8cda2c9a245375a3d12bL124-R124); `src/Xping.Sdk.XUnit/XpingTestFramework.cs` [[5]](diffhunk://#diff-9c2670e442683a8522fb1bea5c7e50dc1c73f79dc8e8dc2206f397d6d7285ba7L18-R20) [[6]](diffhunk://#diff-9c2670e442683a8522fb1bea5c7e50dc1c73f79dc8e8dc2206f397d6d7285ba7L28-L39) [[7]](diffhunk://#diff-9c2670e442683a8522fb1bea5c7e50dc1c73f79dc8e8dc2206f397d6d7285ba7L54-R57)

### Test infrastructure and visibility enhancements

* Added `InternalsVisibleTo` for `Xping.Sdk.Core.Tests` in the project file to improve test coverage and accessibility of internal members. (`src/Xping.Sdk.Core/Xping.Sdk.Core.csproj` [src/Xping.Sdk.Core/Xping.Sdk.Core.csprojR29-R31](diffhunk://#diff-e0de625b1032eaed69ec08372d4e8bea5803fae64636021be22507a6bf763b9bR29-R31))
* Introduced `BuildInvalidConfigHost()` helper for constructing hosts with deliberately invalid configuration, enabling tests of orchestrator error handling. (`tests/Xping.Sdk.Core.Tests/Helpers/ServiceHelper.cs` [tests/Xping.Sdk.Core.Tests/Helpers/ServiceHelper.csR114-R148](diffhunk://#diff-306ab7cfc1bc13b591b53cebcd3f93ef257a18f9923ab69eae73f8ff2586998fR114-R148))
* Minor test code improvements, including exposing orchestrator health status for assertions. (`tests/Xping.Sdk.Core.Tests/Orchestration/XpingContextOrchestratorTests.cs` [tests/Xping.Sdk.Core.Tests/Orchestration/XpingContextOrchestratorTests.csR35](diffhunk://#diff-b309da1621b7c37d93085586bf2655ca30ff55ddc8b776f58468fef86cc5006dR35))

### Dependency and import updates

* Updated using statements and dependency injections to reference new no-op service classes and ensure correct service resolution in orchestrator and test code. (`src/Xping.Sdk.Core/XpingContextOrchestrator.cs` [[1]](diffhunk://#diff-de0491960f82951fc7b18a1ef1d4b2c63b9e62af4425b679277ac3f4b12a1d75R17-R21) `tests/Xping.Sdk.Core.Tests/Orchestration/XpingContextOrchestratorTests.cs` [[2]](diffhunk://#diff-b309da1621b7c37d93085586bf2655ca30ff55ddc8b776f58468fef86cc5006dL13)