### PR TITLE
Refactor TestId to TestFingerprint for clarity

### DIFF
--- a/src/Xping.Sdk.Core/Models/Builders/TestIdentityBuilder.cs
+++ b/src/Xping.Sdk.Core/Models/Builders/TestIdentityBuilder.cs
@@ -12,7 +12,7 @@ namespace Xping.Sdk.Core.Models.Builders;
 /// </summary>
 public sealed class TestIdentityBuilder
 {
-    private string _testId;
+    private string _testFingerprint;
     private string _fullyQualifiedName;
     private string _assembly;
     private string _namespace;
@@ -28,7 +28,7 @@ public sealed class TestIdentityBuilder
     /// </summary>
     public TestIdentityBuilder()
     {
-        _testId = string.Empty;
+        _testFingerprint = string.Empty;
         _fullyQualifiedName = string.Empty;
         _assembly = string.Empty;
         _namespace = string.Empty;
@@ -42,7 +42,7 @@ public sealed class TestIdentityBuilder
     /// </summary>
     public TestIdentityBuilder WithTestId(string testId)
     {
-        _testId = testId;
+        _testFingerprint = testId;
         return this;
     }
 
@@ -133,7 +133,7 @@ public sealed class TestIdentityBuilder
     public TestIdentity Build()
     {
         return new TestIdentity(
-            testId: _testId,
+            testFingerprint: _testFingerprint,
             fullyQualifiedName: _fullyQualifiedName,
             assembly: _assembly,
             @namespace: _namespace,
@@ -150,7 +150,7 @@ public sealed class TestIdentityBuilder
     /// </summary>
     public TestIdentityBuilder Reset()
     {
-        _testId = string.Empty;
+        _testFingerprint = string.Empty;
         _fullyQualifiedName = string.Empty;
         _assembly = string.Empty;
         _namespace = string.Empty;

--- a/src/Xping.Sdk.Core/Models/Executions/TestIdentity.cs
+++ b/src/Xping.Sdk.Core/Models/Executions/TestIdentity.cs
@@ -13,7 +13,7 @@ namespace Xping.Sdk.Core.Models.Executions;
 /// - Parameterized test variations
 /// </summary>
 /// <remarks>
-/// The TestId is a SHA256 hash computed from the fully qualified name and parameters,
+/// The TestFingerprint is a SHA256 hash computed from the fully qualified name and parameters,
 /// ensuring the same test always generates the same ID regardless of execution context.
 /// This enables reliable test tracking and historical analysis across test runs.
 /// </remarks>
@@ -24,7 +24,7 @@ public sealed class TestIdentity
     /// </summary>
     public TestIdentity()
     {
-        TestId = string.Empty;
+        TestFingerprint = string.Empty;
         FullyQualifiedName = string.Empty;
         Assembly = string.Empty;
         Namespace = string.Empty;
@@ -37,7 +37,7 @@ public sealed class TestIdentity
     /// Internal constructor for manual construction.
     /// </summary>
     internal TestIdentity(
-        string testId,
+        string testFingerprint,
         string fullyQualifiedName,
         string assembly,
         string @namespace,
@@ -48,7 +48,7 @@ public sealed class TestIdentity
         string? sourceFile,
         int? sourceLineNumber)
     {
-        TestId = testId;
+        TestFingerprint = testFingerprint;
         FullyQualifiedName = fullyQualifiedName;
         Assembly = assembly;
         Namespace = @namespace;
@@ -68,7 +68,7 @@ public sealed class TestIdentity
     /// Format: SHA256 hash as lowercase hex string (64 characters).
     /// Example: "a3f5e9c2d1b4a7f8e0c9d6b3a2f1e8d5c7b4a9f6e3d0c8b5a2f9e6d3c0b7a4f1"
     /// </remarks>
-    public string TestId { get; init; }
+    public string TestFingerprint { get; init; }
 
     /// <summary>
     /// Gets the fully qualified name of the test.
@@ -76,7 +76,7 @@ public sealed class TestIdentity
     /// </summary>
     /// <remarks>
     /// Example: "MyApp.Tests.CalculatorTests.Add_ReturnSum"
-    /// This may change during refactoring, but TestId remains stable.
+    /// This may change during refactoring, but TestFingerprint remains stable.
     /// </remarks>
     public string FullyQualifiedName { get; init; }
 

--- a/src/Xping.Sdk.Core/Services/Identity/ITestIdentityGenerator.cs
+++ b/src/Xping.Sdk.Core/Services/Identity/ITestIdentityGenerator.cs
@@ -12,7 +12,7 @@ namespace Xping.Sdk.Core.Services.Identity;
 /// environments, and code changes.
 /// </summary>
 /// <remarks>
-/// This generator creates consistent TestId hashes that enable:
+/// This generator creates consistent TestFingerprint hashes that enable:
 /// - Tracking the same test across different environments (CI, local, Docker)
 /// - Monitoring test history across refactorings
 /// - Identifying parameterized test variations
@@ -35,7 +35,7 @@ public interface ITestIdentityGenerator
     /// <param name="displayName">Optional display name for human readability.</param>
     /// <param name="sourceFile">Optional source file path.</param>
     /// <param name="sourceLineNumber">Optional source line number.</param>
-    /// <returns>A complete TestIdentity with stable TestId hash.</returns>
+    /// <returns>A complete TestIdentity with stable TestFingerprint hash.</returns>
     /// <exception cref="ArgumentNullException">Thrown when fullyQualifiedName or assembly is null.</exception>
     /// <exception cref="ArgumentException">Thrown when fullyQualifiedName is an invalid format.</exception>
     TestIdentity Generate(

--- a/src/Xping.Sdk.MSTest/XpingTestBase.cs
+++ b/src/Xping.Sdk.MSTest/XpingTestBase.cs
@@ -149,7 +149,7 @@ public abstract class XpingTestBase
             .Build();
 
         // Record test completion for tracking as previous test
-        services.ExecutionTracker.RecordTestCompletion(threadId, identity.TestId, testName, outcome);
+        services.ExecutionTracker.RecordTestCompletion(threadId, identity.TestFingerprint, testName, outcome);
 
         return execution;
     }

--- a/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
+++ b/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
@@ -192,7 +192,7 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
             .Build();
 
         // Record test completion for tracking as previous test
-        services.ExecutionTracker.RecordTestCompletion(workerId, identity.TestId, test.Name, outcome);
+        services.ExecutionTracker.RecordTestCompletion(workerId, identity.TestFingerprint, test.Name, outcome);
 
         return execution;
     }

--- a/src/Xping.Sdk.XUnit/XpingMessageSink.cs
+++ b/src/Xping.Sdk.XUnit/XpingMessageSink.cs
@@ -277,7 +277,7 @@ public sealed class XpingMessageSink(
             .Build();
 
         // Record test completion for tracking as previous test
-        _executionTracker.RecordTestCompletion(workerId: collectionName, identity.TestId, test.DisplayName, outcome);
+        _executionTracker.RecordTestCompletion(workerId: collectionName, identity.TestFingerprint, test.DisplayName, outcome);
 
         return testExecution;
     }

--- a/tests/Xping.Sdk.Core.Tests/Builders/TestExecutionBuilderTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Builders/TestExecutionBuilderTests.cs
@@ -275,7 +275,7 @@ public sealed class TestExecutionBuilderTests
             .Build();
 
         // Assert
-        Assert.Equal("stable-id", execution.Identity.TestId);
+        Assert.Equal("stable-id", execution.Identity.TestFingerprint);
     }
 
     [Fact]

--- a/tests/Xping.Sdk.Core.Tests/Builders/TestIdentityBuilderTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Builders/TestIdentityBuilderTests.cs
@@ -18,7 +18,7 @@ public sealed class TestIdentityBuilderTests
     {
         var identity = new TestIdentityBuilder().Build();
 
-        Assert.Equal(string.Empty, identity.TestId);
+        Assert.Equal(string.Empty, identity.TestFingerprint);
         Assert.Equal(string.Empty, identity.FullyQualifiedName);
         Assert.Equal(string.Empty, identity.Assembly);
         Assert.Equal(string.Empty, identity.Namespace);
@@ -38,7 +38,7 @@ public sealed class TestIdentityBuilderTests
     public void WithTestId_ShouldSetTestId()
     {
         var identity = new TestIdentityBuilder().WithTestId("stable-id-abc").Build();
-        Assert.Equal("stable-id-abc", identity.TestId);
+        Assert.Equal("stable-id-abc", identity.TestFingerprint);
     }
 
     [Fact]
@@ -147,7 +147,7 @@ public sealed class TestIdentityBuilderTests
         builder.Reset();
         var identity = builder.Build();
 
-        Assert.Equal(string.Empty, identity.TestId);
+        Assert.Equal(string.Empty, identity.TestFingerprint);
         Assert.Equal(string.Empty, identity.FullyQualifiedName);
         Assert.Equal(string.Empty, identity.Assembly);
         Assert.Null(identity.ParameterHash);
@@ -182,7 +182,7 @@ public sealed class TestIdentityBuilderTests
             .WithSourceLineNumber(15)
             .Build();
 
-        Assert.Equal("test-id", identity.TestId);
+        Assert.Equal("test-id", identity.TestFingerprint);
         Assert.Equal("Company.Tests.MyClass.ShouldPass", identity.FullyQualifiedName);
         Assert.Equal("Company.Tests", identity.Assembly);
         Assert.Equal("Company.Tests", identity.Namespace);

--- a/tests/Xping.Sdk.Core.Tests/Identity/TestIdentityGeneratorTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Identity/TestIdentityGeneratorTests.cs
@@ -53,8 +53,8 @@ public sealed class TestIdentityGeneratorTests
         var generator = BuildGenerator();
 
         // Act
-        var id1 = generator.Generate(ValidFqn, ValidAssembly).TestId;
-        var id2 = generator.Generate(ValidFqn, ValidAssembly).TestId;
+        var id1 = generator.Generate(ValidFqn, ValidAssembly).TestFingerprint;
+        var id2 = generator.Generate(ValidFqn, ValidAssembly).TestFingerprint;
 
         // Assert
         Assert.Equal(id1, id2);
@@ -67,8 +67,8 @@ public sealed class TestIdentityGeneratorTests
         var generator = BuildGenerator();
 
         // Act
-        var id1 = generator.Generate("Namespace.ClassA.Test", ValidAssembly).TestId;
-        var id2 = generator.Generate("Namespace.ClassB.Test", ValidAssembly).TestId;
+        var id1 = generator.Generate("Namespace.ClassA.Test", ValidAssembly).TestFingerprint;
+        var id2 = generator.Generate("Namespace.ClassB.Test", ValidAssembly).TestFingerprint;
 
         // Assert
         Assert.NotEqual(id1, id2);
@@ -140,7 +140,7 @@ public sealed class TestIdentityGeneratorTests
         var withoutParams = generator.Generate(ValidFqn, ValidAssembly);
 
         // Assert
-        Assert.NotEqual(withParams.TestId, withoutParams.TestId);
+        Assert.NotEqual(withParams.TestFingerprint, withoutParams.TestFingerprint);
     }
 
     [Fact]


### PR DESCRIPTION
Rename `TestId` to `TestFingerprint` throughout the codebase to enhance clarity and maintain consistency with the Cloud Platform terminology. This change improves the understanding of the purpose of the identifier.