### PR TITLE
Refactor session ID type to Guid for type safety

### DIFF
--- a/src/Xping.Sdk.Core/Models/Builders/TestSessionBuilder.cs
+++ b/src/Xping.Sdk.Core/Models/Builders/TestSessionBuilder.cs
@@ -13,7 +13,7 @@ namespace Xping.Sdk.Core.Models.Builders;
 /// </summary>
 public sealed class TestSessionBuilder
 {
-    private string _sessionId;
+    private Guid _sessionId;
     private DateTime _startedAt;
     private DateTime? _endedAt;
     private EnvironmentInfo _environmentInfo;
@@ -25,7 +25,7 @@ public sealed class TestSessionBuilder
     /// </summary>
     public TestSessionBuilder()
     {
-        _sessionId = Guid.NewGuid().ToString();
+        _sessionId = Guid.NewGuid();
         _startedAt = DateTime.UtcNow;
         _environmentInfo = new EnvironmentInfo();
         _executions = [];
@@ -41,7 +41,7 @@ public sealed class TestSessionBuilder
         if (sessionId == Guid.Empty)
             throw new ArgumentException("Session ID cannot be empty.", nameof(sessionId));
 
-        _sessionId = sessionId.ToString();
+        _sessionId = sessionId;
         return this;
     }
 
@@ -138,7 +138,7 @@ public sealed class TestSessionBuilder
     /// <returns>The builder instance for method chaining.</returns>
     public TestSessionBuilder Reset()
     {
-        _sessionId = Guid.NewGuid().ToString();
+        _sessionId = Guid.NewGuid();
         _startedAt = DateTime.UtcNow;
         _endedAt = null;
         _environmentInfo = new EnvironmentInfo();

--- a/src/Xping.Sdk.Core/Models/TestSession.cs
+++ b/src/Xping.Sdk.Core/Models/TestSession.cs
@@ -20,7 +20,7 @@ public sealed class TestSession
     /// </summary>
     public TestSession()
     {
-        SessionId = Guid.Empty.ToString();
+        SessionId = Guid.Empty;
         StartedAt = DateTime.UtcNow;
         EnvironmentInfo = new EnvironmentInfo();
         Executions = [];
@@ -30,14 +30,16 @@ public sealed class TestSession
     /// Internal constructor for builder.
     /// </summary>
     internal TestSession(
-        string sessionId,
+        Guid sessionId,
         DateTime startedAt,
         EnvironmentInfo environmentInfo,
         IReadOnlyCollection<TestExecution> executions,
         DateTime? endedAt,
         int? totalTestsExpected)
     {
-        SessionId = sessionId ?? throw new ArgumentNullException(nameof(sessionId));
+        if (sessionId == Guid.Empty)
+            throw new ArgumentException("Session ID cannot be empty.", nameof(sessionId));
+        SessionId = sessionId;
         StartedAt = startedAt;
         EnvironmentInfo = environmentInfo ?? throw new ArgumentNullException(nameof(environmentInfo));
         Executions = executions ?? throw new ArgumentNullException(nameof(executions));
@@ -48,7 +50,7 @@ public sealed class TestSession
     /// <summary>
     /// Gets the unique identifier for this test session.
     /// </summary>
-    public string SessionId { get; init; }
+    public Guid SessionId { get; init; }
 
     /// <summary>
     /// Gets when the test session started (UTC).

--- a/src/Xping.Sdk.Core/Services/Upload/Internals/XpingUploader.cs
+++ b/src/Xping.Sdk.Core/Services/Upload/Internals/XpingUploader.cs
@@ -130,7 +130,7 @@ internal sealed class XpingUploader(
             throw new InvalidOperationException("Executions cannot be null or empty");
         }
 
-        string sessionId = testSession.SessionId;
+        string sessionId = testSession.SessionId.ToString();
 #pragma warning disable CA2000 // Caller owns and disposes the request via using (request)
         HttpRequestMessage request = new(
             HttpMethod.Post,

--- a/tests/Xping.Sdk.Core.Tests/Builders/TestSessionBuilderTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Builders/TestSessionBuilderTests.cs
@@ -22,7 +22,7 @@ public sealed class TestSessionBuilderTests
     public void Build_ShouldReturnSession_WithNonEmptySessionId()
     {
         var session = new TestSessionBuilder().Build();
-        Assert.NotEqual(Guid.Empty.ToString(), session.SessionId);
+        Assert.NotEqual(Guid.Empty, session.SessionId);
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public sealed class TestSessionBuilderTests
     {
         var id = Guid.NewGuid();
         var session = new TestSessionBuilder().WithSessionId(id).Build();
-        Assert.Equal(id.ToString(), session.SessionId);
+        Assert.Equal(id, session.SessionId);
     }
 
     [Fact]

--- a/tests/Xping.Sdk.Core.Tests/Orchestration/XpingContextOrchestratorTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Orchestration/XpingContextOrchestratorTests.cs
@@ -206,7 +206,7 @@ public sealed class XpingContextOrchestratorTests
 
         // Assert
         Assert.NotNull(capturedSession);
-        Assert.Equal(orchestrator.SessionId.ToString(), capturedSession.SessionId);
+        Assert.Equal(orchestrator.SessionId, capturedSession.SessionId);
 
         await orchestrator.DisposeAsync();
     }

--- a/tests/Xping.Sdk.Core.Tests/Serialization/XpingJsonDeserializerTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Serialization/XpingJsonDeserializerTests.cs
@@ -45,7 +45,7 @@ public sealed class XpingJsonDeserializerTests
         var session = await serializer.DeserializeAsync<TestSession>(stream);
 
         Assert.NotNull(session);
-        Assert.Equal("dc6cdcdc-8567-439b-8a1d-d86fad27d05e", session!.SessionId);
+        Assert.Equal(Guid.Parse("dc6cdcdc-8567-439b-8a1d-d86fad27d05e"), session!.SessionId);
     }
 
     [Fact]


### PR DESCRIPTION
Change the session ID type from string to Guid to enhance type safety throughout the application. This improves validation and reduces potential errors related to session ID handling.