### PR TITLE
Update documentation and add xping test fingerprint

### DIFF
--- a/docs/getting-started/quickstart-nunit.md
+++ b/docs/getting-started/quickstart-nunit.md
@@ -294,7 +294,7 @@ public void Login_ShouldSucceed(string role, bool expected) { ... }
 // Automatically produces: "login-v1:admin,true" and "login-v1:user,false"
 ```
 
-> **💡 Tip:** Once you publish a run with a pinned fingerprint, treat that value as permanent. Renaming the method is safe—that is the whole point—but changing the attribute value itself severs the link to all historical data for that test.
+> **Important:** Once you publish a run with a pinned fingerprint, treat that value as permanent. Renaming the method is safe—that is the whole point—but changing the attribute value itself severs the link to all historical data for that test.
 
 ---
 

--- a/samples/SampleApp.NUnit/SampleTests.cs
+++ b/samples/SampleApp.NUnit/SampleTests.cs
@@ -6,6 +6,7 @@
 namespace SampleApp.NUnit;
 
 using global::NUnit.Framework;
+using Xping.Sdk.Core.Attributes;
 using Xping.Sdk.NUnit;
 
 #pragma warning disable CA1707 // Identifiers should not contain underscores
@@ -55,6 +56,7 @@ public class SampleTests
     [Category("Flaky")]
     [Category("Random")]
     [Description("Demonstrates a flaky test that fails randomly due to probabilistic behavior")]
+    [XpingFingerprint("flaky-random-failure-v1")] // Pin a constant fingerprint to maintain historical data across refactors
     public void FlakyTest_RandomFailure_FailsProbabilistically()
     {
         // Use a pseudo-random seed based on time to get different results per run

--- a/samples/SampleApp.NUnit/SampleTests.cs
+++ b/samples/SampleApp.NUnit/SampleTests.cs
@@ -6,6 +6,7 @@
 namespace SampleApp.NUnit;
 
 using global::NUnit.Framework;
+using Xping.Sdk.Core.Attributes;
 using Xping.Sdk.NUnit;
 
 #pragma warning disable CA1707 // Identifiers should not contain underscores
@@ -58,6 +59,7 @@ public class SampleTests
     [Category("Flaky")]
     [Category("Random")]
     [Description("Demonstrates a flaky test that fails randomly due to probabilistic behavior")]
+    [XpingFingerprint("flaky-random-failure-v1")] // Pin a constant fingerprint to maintain historical data across refactors
     public async Task FlakyTest_RandomFailure_FailsProbabilistically()
     {
         // Random.Shared is cryptographically seeded by the runtime — no TickCount bias.


### PR DESCRIPTION
This pull request introduces improvements to the sample NUnit test suite and documentation, focusing on test tracking and clarity for maintaining historical data. The most important changes are grouped below:

Enhancements to test tracking:

* Added the `[XpingFingerprint("flaky-random-failure-v1")]` attribute to the `FlakyTest_RandomFailure_FailsProbabilistically` test in `SampleTests.cs` to ensure consistent tracking of test history across refactors.
* Imported `Xping.Sdk.Core.Attributes` in `SampleTests.cs` to support the use of fingerprint attributes.

Documentation updates:

* Updated the tip in `quickstart-nunit.md` to emphasize the importance of treating pinned fingerprints as permanent, clarifying the impact of changing attribute values on historical test data.