### PR TITLE
Update OS version formatting in EnvironmentDetector

### DIFF
--- a/src/Xping.Sdk.Core/Services/Environment/Internals/EnvironmentDetector.cs
+++ b/src/Xping.Sdk.Core/Services/Environment/Internals/EnvironmentDetector.cs
@@ -181,12 +181,12 @@ internal sealed class EnvironmentDetector : IEnvironmentDetector
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                return $"Linux ({description})";
+                return $"Linux {os.Version.Major}.{os.Version.Minor}.{os.Version.Build}";
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return $"macOS ({description})";
+                return $"macOS {os.Version.Major}.{os.Version.Minor}.{os.Version.Build}";
             }
 
             return description;


### PR DESCRIPTION
Refine the formatting of the operating system version strings for Linux and macOS to include version numbers without parentheses.