### PR TITLE
Standardize framework tag casing for MSTest, NUnit, and xUnit

### DIFF
--- a/src/Xping.Sdk.MSTest/XpingTestBase.cs
+++ b/src/Xping.Sdk.MSTest/XpingTestBase.cs
@@ -188,7 +188,7 @@ public abstract class XpingTestBase
     {
         TestMetadataBuilder builder = new();
 
-        builder.AddTag("framework:mstest");
+        builder.AddTag("framework:MSTest");
 
         // Extract properties
         if (context.Properties.Keys is { Count: > 0})

--- a/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
+++ b/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
@@ -291,7 +291,7 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
         TestMetadataBuilder builder = new();
 
         // Add common tags
-        builder.AddTag("framework:nunit");
+        builder.AddTag("framework:NUnit");
         builder.AddTag(test.IsSuite ? "type:suite" : "type:test");
 
         // Add a fixture type name if available

--- a/src/Xping.Sdk.XUnit/XpingMessageSink.cs
+++ b/src/Xping.Sdk.XUnit/XpingMessageSink.cs
@@ -294,7 +294,7 @@ public sealed class XpingMessageSink(
 
         ITestCase? testCase = test.TestCase;
         List<string> categories = [];
-        List<string> tags = ["framework:xunit"];
+        List<string> tags = ["framework:xUnit"];
         Dictionary<string, string> customAttributes = [];
 
         // Extract traits as categories


### PR DESCRIPTION
Ensure consistent casing for framework tags across MSTest, NUnit, and xUnit in the metadata extraction process.