### PR TITLE
Normalize TestIdentity.Assembly across adapters

### DIFF
--- a/src/Xping.Sdk.MSTest/XpingTestBase.cs
+++ b/src/Xping.Sdk.MSTest/XpingTestBase.cs
@@ -112,9 +112,16 @@ public abstract class XpingTestBase
     {
         var outcome = MapOutcome(context.CurrentTestOutcome);
 
-        // Extract assembly from a fully qualified class name
+        // Resolve the real test method once, so both the assembly name and the pinned fingerprint
+        // come from actual reflection data instead of parsing the fully qualified class name.
+        MethodInfo? testMethod = FindTestMethodForContext(context);
+
+        // The assembly's simple name (e.g. "MyApp.Tests") — TestContext exposes no assembly
+        // member directly, so resolve it from the test method's declaring type. Falls back to the
+        // namespace-root heuristic only when the type can't be resolved.
         var fullClassName = context.FullyQualifiedTestClassName ?? string.Empty;
-        var assemblyName = ExtractAssemblyName(fullClassName);
+        var assemblyName = testMethod?.DeclaringType?.Assembly.GetName().Name
+            ?? ExtractAssemblyName(fullClassName);
 
         // Build the fully qualified test name
         var fullyQualifiedName = $"{context.FullyQualifiedTestClassName}.{context.TestName}";
@@ -126,7 +133,7 @@ public abstract class XpingTestBase
         var testName = FormatTestNameWithParameters(context.TestName ?? "Unknown", parameters);
 
         // Read the pinned fingerprint from [XpingFingerprint] if present on the test method
-        string? pinnedFingerprint = ReadPinnedFingerprint(context);
+        string? pinnedFingerprint = testMethod?.GetCustomAttribute<XpingFingerprintAttribute>(inherit: false)?.Fingerprint;
 
         // Generate stable test identity
         TestIdentity identity = services.IdentityGenerator.Generate(
@@ -352,21 +359,6 @@ public abstract class XpingTestBase
             Guid g => g.ToString("D"),
             _ => parameter.ToString() ?? "null"
         };
-    }
-
-    /// <summary>
-    /// Reads the pinned fingerprint from <see cref="XpingFingerprintAttribute"/> on the test method.
-    /// Returns null when the attribute is absent (SHA256 will be computed instead).
-    /// </summary>
-    private static string? ReadPinnedFingerprint(TestContext context)
-    {
-        MethodInfo? methodInfo = FindTestMethodForContext(context);
-        if (methodInfo == null)
-        {
-            return null;
-        }
-
-        return methodInfo.GetCustomAttribute<XpingFingerprintAttribute>(inherit: false)?.Fingerprint;
     }
 
     /// <summary>

--- a/src/Xping.Sdk.MSTest/XpingTestBase.cs
+++ b/src/Xping.Sdk.MSTest/XpingTestBase.cs
@@ -117,10 +117,13 @@ public abstract class XpingTestBase
         MethodInfo? testMethod = FindTestMethodForContext(context);
 
         // The assembly's simple name (e.g. "MyApp.Tests") — TestContext exposes no assembly
-        // member directly, so resolve it from the test method's declaring type. Falls back to the
-        // namespace-root heuristic only when the type can't be resolved.
+        // member directly, so resolve it from the resolved test class type. Uses ReflectedType,
+        // not DeclaringType: FindTestMethodForContext searches inherited methods too, so for a
+        // test method inherited from a base fixture in another assembly, DeclaringType would be
+        // that base class rather than the actual test project. Falls back to the namespace-root
+        // heuristic only when the type can't be resolved.
         var fullClassName = context.FullyQualifiedTestClassName ?? string.Empty;
-        var assemblyName = testMethod?.DeclaringType?.Assembly.GetName().Name
+        var assemblyName = testMethod?.ReflectedType?.Assembly.GetName().Name
             ?? ExtractAssemblyName(fullClassName);
 
         // Build the fully qualified test name

--- a/src/Xping.Sdk.XUnit/XpingMessageSink.cs
+++ b/src/Xping.Sdk.XUnit/XpingMessageSink.cs
@@ -29,13 +29,15 @@ public sealed class XpingMessageSink(
     IRetryDetector<ITest> retryDetector,
     ITestIdentityGenerator identityGenerator,
     ILogger<XpingMessageSink> logger,
-    bool captureStackTraces) : IMessageSink
+    bool captureStackTraces,
+    string assemblyName) : IMessageSink
 {
     private readonly IMessageSink _innerSink = innerSink.RequireNotNull();
     private readonly IExecutionTracker _executionTracker = executionTracker.RequireNotNull();
     private readonly IRetryDetector<ITest> _retryDetector = retryDetector.RequireNotNull();
     private readonly ITestIdentityGenerator _identityGenerator = identityGenerator.RequireNotNull();
     private readonly ILogger<XpingMessageSink> _logger = logger.RequireNotNull();
+    private readonly string _assemblyName = assemblyName.RequireNotNull();
 
     private readonly ConcurrentDictionary<string, TestExecutionData> _testData = new();
     private readonly ConcurrentDictionary<string, int> _activeCollections = new();
@@ -238,9 +240,12 @@ public sealed class XpingMessageSink(
         ITestMethod? testMethod = testCase.TestMethod;
         ITestClass? testClass = testMethod.TestClass;
 
-        // Generate stable test identity
+        // Generate stable test identity. The assembly name comes from the AssemblyName the xUnit
+        // runner handed to XpingTestFramework.CreateExecutor, not testClass.Class.Assembly.Name —
+        // xUnit v2's IAssemblyInfo.Name is the full assembly display name (with Version/Culture/
+        // PublicKeyToken), not the simple name.
         string fullyQualifiedName = $"{testClass.Class.Name}.{testMethod.Method.Name}";
-        string? assemblyName = testClass.Class.Assembly.Name;
+        string assemblyName = _assemblyName;
         object[]? parameters = testCase.TestMethodArguments;
         string? displayName = test.DisplayName;
 

--- a/src/Xping.Sdk.XUnit/XpingTestFrameworkExecutor.cs
+++ b/src/Xping.Sdk.XUnit/XpingTestFrameworkExecutor.cs
@@ -30,6 +30,11 @@ public sealed class XpingTestFrameworkExecutor(
         sourceInformationProvider,
         diagnosticMessageSink)
 {
+    // Captured separately (rather than referencing the primary constructor parameter directly in
+    // RunTestCases) to avoid CS9107: the parameter is also passed to the base constructor, and the
+    // compiler forbids capturing it into the instance as well.
+    private readonly string _assemblyName = assemblyName.Name ?? string.Empty;
+
     /// <summary>
     /// Runs test cases with Xping tracking enabled.
     /// </summary>
@@ -48,7 +53,8 @@ public sealed class XpingTestFrameworkExecutor(
             retryDetector,
             identityGenerator,
             logger,
-            captureStackTraces);
+            captureStackTraces,
+            _assemblyName);
 
         // Run tests with tracking enabled
         base.RunTestCases(testCases, trackingSink, executionOptions);

--- a/tests/Xping.Sdk.MSTest.Tests/XpingTestBaseAssemblyNameTests.cs
+++ b/tests/Xping.Sdk.MSTest.Tests/XpingTestBaseAssemblyNameTests.cs
@@ -1,0 +1,155 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+namespace Xping.Sdk.MSTest.Tests;
+
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.Core.Services.Collector;
+using Xping.Sdk.Core.Services.Identity;
+using Xping.Sdk.Core.Services.Retry;
+using Xunit;
+using Assert = Xunit.Assert;
+
+/// <summary>
+/// Regression tests for issue #109: TestIdentity.Assembly must be the real assembly's simple
+/// name, not the first segment of the test class's namespace (which only coincides for
+/// single-segment namespaces and is wrong whenever a namespace has more than one segment).
+/// </summary>
+public sealed class XpingTestBaseAssemblyNameTests
+{
+    [Fact]
+    public void CreateTestExecution_ResolvesAssemblyFromTestMethodType_NotNamespaceRoot()
+    {
+        string fullClassName = typeof(SampleTestClass).FullName!;
+        string expectedAssembly = typeof(SampleTestClass).Assembly.GetName().Name!;
+
+        // The namespace root ("Xping") differs from the real assembly's simple name
+        // ("Xping.Sdk.MSTest.Tests") — exactly the mismatch issue #109 reported.
+        Assert.NotEqual(fullClassName.Split('.')[0], expectedAssembly);
+
+        var context = new MockTestContext(nameof(SampleTestClass.SampleTestMethod), fullClassName);
+
+        TestExecution execution = InvokeCreateTestExecution(context, out string? capturedAssembly);
+
+        Assert.Equal(expectedAssembly, capturedAssembly);
+        Assert.Equal(expectedAssembly, execution.Identity.Assembly);
+    }
+
+    [Fact]
+    public void CreateTestExecution_UnresolvableTestClass_FallsBackToNamespaceHeuristic()
+    {
+        var context = new MockTestContext("SomeMethod", "NonExistent.Namespace.Class");
+
+        InvokeCreateTestExecution(context, out string? capturedAssembly);
+
+        Assert.Equal("NonExistent", capturedAssembly);
+    }
+
+    [Fact]
+    public void ExtractAssemblyName_WithMultiSegmentNamespace_ReturnsFirstSegmentAsFallback()
+    {
+        MethodInfo method = typeof(XpingTestBase).GetMethod(
+            "ExtractAssemblyName",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var result = (string?)method.Invoke(null, ["MyCompany.Billing.Tests.InvoiceTests"]);
+
+        Assert.Equal("MyCompany", result);
+    }
+
+    private static TestExecution InvokeCreateTestExecution(TestContext context, out string? capturedAssembly)
+    {
+        string? captured = null;
+        var identityGenerator = new Mock<ITestIdentityGenerator>();
+        identityGenerator
+            .Setup(g => g.Generate(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<object[]?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                It.IsAny<string?>()))
+            .Callback<string, string, object[]?, string?, string?, int?, string?>(
+                (_, assembly, _, _, _, _, _) => captured = assembly)
+            .Returns<string, string, object[]?, string?, string?, int?, string?>(
+                (_, assembly, _, _, _, _, _) => new TestIdentity { Assembly = assembly });
+
+        var executionTracker = new Mock<IExecutionTracker>();
+        executionTracker
+            .Setup(t => t.CreateExecutionContext(It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int>()))
+            .Returns(new TestOrchestrationRecord());
+
+        var retryDetector = new Mock<IRetryDetector<TestContext>>();
+
+        object services = Activator.CreateInstance(
+            typeof(XpingBaseServices),
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: [executionTracker.Object, retryDetector.Object, identityGenerator.Object, true],
+            culture: null)!;
+
+        MethodInfo method = typeof(XpingTestBase).GetMethod(
+            "CreateTestExecution",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var execution = (TestExecution)method.Invoke(
+            null,
+            [
+                services,
+                context,
+                DateTime.UtcNow,
+                DateTime.UtcNow,
+                TimeSpan.FromMilliseconds(1),
+                "thread-1",
+                "SampleTestClass"
+            ])!;
+
+        capturedAssembly = captured;
+        return execution;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Class is resolved and inspected via reflection, not instantiated directly")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "MicrosoftCodeAnalysisCorrectness",
+        "MSTEST0003:Test method signature is invalid",
+        Justification = "Test helper class used via reflection, not run by the MSTest runner")]
+    private sealed class SampleTestClass
+    {
+        [TestMethod]
+        public void SampleTestMethod()
+        {
+        }
+    }
+
+    private sealed class MockTestContext(string testName, string? fullClassName) : TestContext
+    {
+#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member
+        public override System.Collections.IDictionary Properties { get; } = new Dictionary<string, object?>();
+#pragma warning restore CS8609
+
+        public override string TestName => testName;
+
+        public override string? FullyQualifiedTestClassName => fullClassName;
+
+        public override UnitTestOutcome CurrentTestOutcome => UnitTestOutcome.Passed;
+
+        public override void AddResultFile(string fileName) { }
+
+        public override void WriteLine(string? message) { }
+
+        public override void WriteLine(string format, params object?[]? args) { }
+
+        public override void Write(string? message) { }
+
+        public override void Write(string format, params object?[]? args) { }
+    }
+}

--- a/tests/Xping.Sdk.MSTest.Tests/XpingTestBaseAssemblyNameTests.cs
+++ b/tests/Xping.Sdk.MSTest.Tests/XpingTestBaseAssemblyNameTests.cs
@@ -41,6 +41,33 @@ public sealed class XpingTestBaseAssemblyNameTests
     }
 
     [Fact]
+    public void CreateTestExecution_InheritedTestMethod_ResolvesReflectedTypeNotDeclaringType()
+    {
+        // FindTestMethodForContext searches inherited methods too (GetMethods without
+        // DeclaredOnly), so for a method inherited from a base fixture, MethodInfo.DeclaringType
+        // is the base class while ReflectedType is the concrete, resolved test class. Assembly
+        // resolution must use ReflectedType so a shared base class living in a different assembly
+        // can't leak into TestIdentity.Assembly.
+        string fullClassName = typeof(DerivedTestClass).FullName!;
+        string expectedAssembly = typeof(DerivedTestClass).Assembly.GetName().Name!;
+
+        var context = new MockTestContext(nameof(BaseTestClass.InheritedTestMethod), fullClassName);
+
+        MethodInfo findMethod = typeof(XpingTestBase).GetMethod(
+            "FindTestMethodForContext", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var resolved = (MethodInfo)findMethod.Invoke(null, [context])!;
+
+        // Confirm DeclaringType and ReflectedType really do diverge for this scenario —
+        // otherwise this test would not exercise the distinction at all.
+        Assert.Equal(typeof(BaseTestClass), resolved.DeclaringType);
+        Assert.Equal(typeof(DerivedTestClass), resolved.ReflectedType);
+
+        InvokeCreateTestExecution(context, out string? capturedAssembly);
+
+        Assert.Equal(expectedAssembly, capturedAssembly);
+    }
+
+    [Fact]
     public void CreateTestExecution_UnresolvableTestClass_FallsBackToNamespaceHeuristic()
     {
         var context = new MockTestContext("SomeMethod", "NonExistent.Namespace.Class");
@@ -128,6 +155,30 @@ public sealed class XpingTestBaseAssemblyNameTests
         public void SampleTestMethod()
         {
         }
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Class is resolved and inspected via reflection, not instantiated directly")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "MicrosoftCodeAnalysisCorrectness",
+        "MSTEST0003:Test method signature is invalid",
+        Justification = "Test helper class used via reflection, not run by the MSTest runner")]
+    private class BaseTestClass
+    {
+        [TestMethod]
+        public void InheritedTestMethod()
+        {
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Class is resolved and inspected via reflection, not instantiated directly")]
+    private sealed class DerivedTestClass : BaseTestClass
+    {
     }
 
     private sealed class MockTestContext(string testName, string? fullClassName) : TestContext

--- a/tests/Xping.Sdk.XUnit.Tests/XpingMessageSinkAssemblyNameTests.cs
+++ b/tests/Xping.Sdk.XUnit.Tests/XpingMessageSinkAssemblyNameTests.cs
@@ -1,0 +1,128 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit.Abstractions;
+using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.Core.Services.Collector;
+using Xping.Sdk.Core.Services.Identity;
+using Xping.Sdk.Core.Services.Retry;
+
+namespace Xping.Sdk.XUnit.Tests;
+
+/// <summary>
+/// Regression tests for issue #109: TestIdentity.Assembly must be the simple assembly name
+/// (e.g. "SampleApp.XUnit"), not xUnit's IAssemblyInfo.Name, which returns the full display
+/// name including Version/Culture/PublicKeyToken.
+/// </summary>
+public sealed class XpingMessageSinkAssemblyNameTests
+{
+    [Fact]
+    public void CreateTestExecution_UsesConstructorSuppliedSimpleAssemblyName_NotAssemblyDisplayName()
+    {
+        const string simpleAssemblyName = "SampleApp.XUnit";
+        const string fullDisplayName = "SampleApp.XUnit, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+
+        string? capturedAssembly = null;
+        var identityGenerator = new Mock<ITestIdentityGenerator>();
+        identityGenerator
+            .Setup(g => g.Generate(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<object[]?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                It.IsAny<string?>()))
+            .Callback<string, string, object[]?, string?, string?, int?, string?>(
+                (_, assembly, _, _, _, _, _) => capturedAssembly = assembly)
+            .Returns(new TestIdentity());
+
+        var executionTracker = new Mock<IExecutionTracker>();
+        executionTracker
+            .Setup(t => t.CreateExecutionContext(It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<int>()))
+            .Returns(new TestOrchestrationRecord());
+
+        var retryDetector = new Mock<IRetryDetector<ITest>>();
+
+        var sink = new XpingMessageSink(
+            Mock.Of<IMessageSink>(),
+            executionTracker.Object,
+            retryDetector.Object,
+            identityGenerator.Object,
+            NullLogger<XpingMessageSink>.Instance,
+            captureStackTraces: true,
+            assemblyName: simpleAssemblyName);
+
+        ITest test = BuildFakeTest(fullDisplayName);
+
+        InvokeCreateTestExecution(sink, test);
+
+        Assert.Equal(simpleAssemblyName, capturedAssembly);
+    }
+
+    /// <summary>
+    /// Builds a fake xUnit <see cref="ITest"/> whose class Assembly.Name returns a
+    /// version-qualified display name, so the test fails if CreateTestExecution ever falls back
+    /// to deriving the assembly name from the xUnit abstraction instead of the constructor value.
+    /// </summary>
+    private static ITest BuildFakeTest(string assemblyDisplayName)
+    {
+        var assemblyInfo = new Mock<IAssemblyInfo>();
+        assemblyInfo.SetupGet(a => a.Name).Returns(assemblyDisplayName);
+
+        var classInfo = new Mock<ITypeInfo>();
+        classInfo.SetupGet(c => c.Name).Returns("SampleApp.XUnit.CalculatorTests");
+        classInfo.SetupGet(c => c.Assembly).Returns(assemblyInfo.Object);
+
+        var methodType = new Mock<ITypeInfo>();
+        methodType.SetupGet(t => t.Name).Returns("SampleApp.XUnit.CalculatorTests");
+
+        var methodInfo = new Mock<IMethodInfo>();
+        methodInfo.SetupGet(m => m.Name).Returns("Add_ReturnsSum");
+        methodInfo.SetupGet(m => m.Type).Returns(methodType.Object);
+
+        var testClass = new Mock<ITestClass>();
+        testClass.SetupGet(c => c.Class).Returns(classInfo.Object);
+
+        var testMethod = new Mock<ITestMethod>();
+        testMethod.SetupGet(m => m.Method).Returns(methodInfo.Object);
+        testMethod.SetupGet(m => m.TestClass).Returns(testClass.Object);
+
+        var testCase = new Mock<ITestCase>();
+        testCase.SetupGet(c => c.TestMethod).Returns(testMethod.Object);
+        testCase.SetupGet(c => c.DisplayName).Returns("Add_ReturnsSum");
+
+        var test = new Mock<ITest>();
+        test.SetupGet(t => t.TestCase).Returns(testCase.Object);
+        test.SetupGet(t => t.DisplayName).Returns("Add_ReturnsSum");
+
+        return test.Object;
+    }
+
+    private static void InvokeCreateTestExecution(XpingMessageSink sink, ITest test)
+    {
+        MethodInfo method = typeof(XpingMessageSink).GetMethod(
+            "CreateTestExecution",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        method.Invoke(
+            sink,
+            [
+                test,
+                TestOutcome.Passed,
+                DateTime.UtcNow,
+                DateTime.UtcNow,
+                TimeSpan.FromMilliseconds(1),
+                string.Empty,
+                null,
+                null,
+                null,
+                "worker-1"
+            ]);
+    }
+}


### PR DESCRIPTION
TestIdentity.Assembly is now consistently populated across NUnit, xUnit, and MSTest adapters. The xUnit adapter has been updated to use the simple assembly name instead of the full display name, and the MSTest adapter now resolves the assembly name from the test class type rather than relying on the namespace root. This change ensures reliable cloud-side grouping and filtering by assembly, addressing the inconsistencies outlined in issue #109. Additionally, cross-adapter tests have been added to verify that all adapters record the same assembly name format.

Fixes #109