### PR TITLE
Integrate XpingVersion for consistent SDK versioning

### DIFF
--- a/src/Xping.Cli/Program.cs
+++ b/src/Xping.Cli/Program.cs
@@ -6,8 +6,8 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Globalization;
-using System.Reflection;
 using Xping.Cli.Commands;
+using Xping.Sdk.Shared;
 
 namespace Xping.Cli;
 
@@ -32,7 +32,7 @@ internal static class Program
 
         bool noArgs = args.Length == 0;
 
-        // Matches the historical bare-word `help` verb; `--help`/`-h` are already recognised by
+        // Matches the historical bare-word `help` verb; `--help`/`-h` are already recognized by
         // the root command itself.
         string[] effectiveArgs = noArgs
             ? ["--help"]
@@ -211,24 +211,15 @@ internal static class Program
     {
         Command command = new("version", "Print the tool version");
 
-        // Reads the same AssemblyInformationalVersionAttribute that System.CommandLine's built-in
-        // `--version` root option uses, so `xping version` and `xping --version` always agree.
+        // Uses the shared XpingSdkVersion (the same clean SemVer reported in the SDK's User-Agent
+        // header and TestSession.SdkVersion), so it may omit the local source-revision suffix
+        // (e.g. "+abc123") that System.CommandLine's built-in `--version` option can include.
         command.SetAction(_ =>
         {
-            output.WriteLine(GetInformationalVersion());
+            output.WriteLine(XpingVersion.Current);
             return 0;
         });
 
         return command;
-    }
-
-    private static string GetInformationalVersion()
-    {
-        AssemblyInformationalVersionAttribute? attribute = typeof(Program).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-
-        return attribute?.InformationalVersion is { Length: > 0 } version
-            ? version
-            : typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown";
     }
 }

--- a/src/Xping.Cli/Xping.Cli.csproj
+++ b/src/Xping.Cli/Xping.Cli.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Xping.Sdk.Core\Xping.Sdk.Core.csproj" />
+    <ProjectReference Include="..\Xping.Sdk.Shared\Xping.Sdk.Shared.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Xping.Sdk.Core/Extensions/XpingServiceCollectionExtensions.cs
+++ b/src/Xping.Sdk.Core/Extensions/XpingServiceCollectionExtensions.cs
@@ -491,7 +491,7 @@ public static class XpingServiceCollectionExtensions
                 new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
             client.DefaultRequestHeaders.Add("X-API-Key", config.ApiKey);
             client.DefaultRequestHeaders.Add("X-Project-Id", config.ProjectId);
-            client.DefaultRequestHeaders.Add("User-Agent", $"Xping-SDK-DotNet/{XpingSdkVersion.Current}");
+            client.DefaultRequestHeaders.Add("User-Agent", $"Xping-SDK-DotNet/{XpingVersion.Current}");
         })
         .AddResilienceHandler("xping-upload-resilience", (builder, context) =>
         {

--- a/src/Xping.Sdk.Core/Models/TestSession.cs
+++ b/src/Xping.Sdk.Core/Models/TestSession.cs
@@ -3,7 +3,6 @@
  * License: [MIT]
  */
 
-using Xping.Sdk.Core;
 using Xping.Sdk.Core.Models.Environments;
 using Xping.Sdk.Core.Models.Executions;
 using Xping.Sdk.Core.Models.PullRequests;
@@ -31,7 +30,7 @@ public sealed class TestSession
         SessionState = TestSessionState.Initial;
         PullRequestContext = null;
         QuickStatistics = null;
-        SdkVersion = XpingSdkVersion.Current;
+        SdkVersion = XpingVersion.Current;
     }
 
     /// <summary>
@@ -57,7 +56,7 @@ public sealed class TestSession
         SessionState = sessionState;
         PullRequestContext = pullRequestContext;
         QuickStatistics = quickStatistics;
-        SdkVersion = XpingSdkVersion.Current;
+        SdkVersion = XpingVersion.Current;
     }
 
     /// <summary>

--- a/src/Xping.Sdk.Core/XpingContextOrchestrator.cs
+++ b/src/Xping.Sdk.Core/XpingContextOrchestrator.cs
@@ -65,7 +65,7 @@ public abstract class XpingContextOrchestrator : IAsyncDisposable
     private readonly ILocalRunWriter? _localRunWriter;
 
     // Slim projections of every execution drained during this session. Accumulated at drain time
-    // rather than in RecordTestExecution so the per-test hot path stays free of any local-store work.
+    // rather than in RecordTestExecution, so the per-test hot path stays free of any local-store work.
     private readonly List<LocalTestRecord> _localRecords = [];
     private readonly object _localRecordsLock = new();
 

--- a/src/Xping.Sdk.Shared/XpingVersion.cs
+++ b/src/Xping.Sdk.Shared/XpingVersion.cs
@@ -5,7 +5,7 @@
 
 using System.Reflection;
 
-namespace Xping.Sdk.Core;
+namespace Xping.Sdk.Shared;
 
 /// <summary>
 /// Provides the current version of the Xping SDK, read from assembly metadata at runtime.
@@ -24,7 +24,7 @@ namespace Xping.Sdk.Core;
 /// string version = XpingSdkVersion.Current; // e.g. "1.2.3" or "1.3.0-beta.1"
 /// </code>
 /// </example>
-public static class XpingSdkVersion
+public static class XpingVersion
 {
     /// <summary>
     /// The current version of the Xping SDK (e.g. <c>"1.2.3"</c> or <c>"1.3.0-beta.1"</c>).
@@ -33,7 +33,7 @@ public static class XpingSdkVersion
 
     private static string ReadVersion()
     {
-        var attribute = typeof(XpingSdkVersion).Assembly
+        var attribute = typeof(XpingVersion).Assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>();
 
         if (attribute == null)

--- a/tests/Xping.Sdk.Core.Tests/Models/TestSessionTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Models/TestSessionTests.cs
@@ -3,10 +3,10 @@
  * License: [MIT]
  */
 
-using Xping.Sdk.Core;
 using Xping.Sdk.Core.Models;
 using Xping.Sdk.Core.Models.Builders;
 using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.Shared;
 
 namespace Xping.Sdk.Core.Tests.Models;
 
@@ -21,7 +21,7 @@ public sealed class TestSessionTests
     {
         var session = new TestSession();
 
-        Assert.Equal(XpingSdkVersion.Current, session.SdkVersion);
+        Assert.Equal(XpingVersion.Current, session.SdkVersion);
     }
 
     // ---------------------------------------------------------------------------
@@ -39,6 +39,6 @@ public sealed class TestSessionTests
                     .Build())
             .Build();
 
-        Assert.Equal(XpingSdkVersion.Current, session.SdkVersion);
+        Assert.Equal(XpingVersion.Current, session.SdkVersion);
     }
 }

--- a/tests/Xping.Sdk.Core.Tests/Upload/XpingUploaderTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Upload/XpingUploaderTests.cs
@@ -9,13 +9,13 @@ using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 using Polly.CircuitBreaker;
-using Xping.Sdk.Core;
 using Xping.Sdk.Core.Configuration;
 using Xping.Sdk.Core.Extensions;
 using Xping.Sdk.Core.Models;
 using Xping.Sdk.Core.Models.Builders;
 using Xping.Sdk.Core.Models.Executions;
 using Xping.Sdk.Core.Services.Upload;
+using Xping.Sdk.Shared;
 
 namespace Xping.Sdk.Core.Tests.Upload;
 
@@ -416,6 +416,6 @@ public sealed class XpingUploaderTests
         // Assert
         Assert.NotNull(captured);
         Assert.True(captured.Headers.TryGetValues("User-Agent", out var values));
-        Assert.Equal($"Xping-SDK-DotNet/{XpingSdkVersion.Current}", string.Join(" ", values));
+        Assert.Equal($"Xping-SDK-DotNet/{XpingVersion.Current}", string.Join(" ", values));
     }
 }

--- a/tests/Xping.Sdk.Core.Tests/Xping.Sdk.Core.Tests.csproj
+++ b/tests/Xping.Sdk.Core.Tests/Xping.Sdk.Core.Tests.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Xping.Sdk.Core\Xping.Sdk.Core.csproj" />
+    <ProjectReference Include="..\..\src\Xping.Sdk.Shared\Xping.Sdk.Shared.csproj" />
     <ProjectReference Include="..\..\src\Xping.Sdk.XUnit\Xping.Sdk.XUnit.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Introduce XpingVersion to standardize SDK versioning across components, replacing previous references to XpingSdkVersion. This change ensures consistent version reporting in various parts of the application.