### PR TITLE
fix: measure real test concurrency for WasParallelized/ConcurrentTestCount (#120)

### DIFF
--- a/src/Xping.Sdk.Core/Models/Executions/TestOrchestrationRecord.cs
+++ b/src/Xping.Sdk.Core/Models/Executions/TestOrchestrationRecord.cs
@@ -85,14 +85,20 @@ public sealed class TestOrchestrationRecord
     // Parallelization
 
     /// <summary>
-    /// Gets a value indicating whether this test was executed in parallel with other tests.
+    /// Gets a value indicating whether at least one other test was observed running concurrently with
+    /// this test at any point during its execution. Equivalent to <see cref="ConcurrentTestCount"/>
+    /// being greater than <c>1</c>.
     /// </summary>
     public bool WasParallelized { get; init; }
 
     /// <summary>
-    /// Gets the number of tests executing concurrently at the time this test started.
-    /// 1 for sequential execution.
+    /// Gets the peak number of tests observed running concurrently at any point while this test was
+    /// executing, including this test itself. <c>1</c> when this test ran on its own.
     /// </summary>
+    /// <remarks>
+    /// Measured from the test start and end notifications reported by the test framework adapter.
+    /// Integrations that do not report test starts always yield <c>1</c>.
+    /// </remarks>
     public int ConcurrentTestCount { get; init; }
 
     /// <summary>

--- a/src/Xping.Sdk.Core/Services/Collector/IExecutionTracker.cs
+++ b/src/Xping.Sdk.Core/Services/Collector/IExecutionTracker.cs
@@ -40,7 +40,46 @@ public interface IExecutionTracker
     /// <returns>
     /// An <see cref="TestOrchestrationRecord"/> containing order, parallelization, and suite state information.
     /// </returns>
+    /// <remarks>
+    /// Parallelization is measured from the test start and end notifications reported through
+    /// <see cref="RecordTestStart"/> and <see cref="RecordTestEnd"/>. Callers that never report a
+    /// test start always get <see cref="TestOrchestrationRecord.ConcurrentTestCount"/> of <c>1</c>.
+    /// </remarks>
     TestOrchestrationRecord CreateExecutionContext(string? workerId = null, string? collectionName = null, int attemptNumber = 1);
+
+    /// <summary>
+    /// Signals that a test has started executing on the specified worker, so that the tests it
+    /// overlaps with can be measured.
+    /// </summary>
+    /// <param name="workerId">
+    /// Optional worker identifier (e.g., NUnit WorkerId, xUnit collection name, MSTest thread ID).
+    /// Falls back to the current managed thread ID if <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    /// The number of tests in flight after this test was registered, including this test.
+    /// Always at least <c>1</c>.
+    /// </returns>
+    /// <remarks>
+    /// Each worker acts as a single in-flight slot, because every supported test framework runs at
+    /// most one test per worker at a time. Calling this method twice for the same worker without an
+    /// intervening <see cref="RecordTestEnd"/> therefore replaces the previous slot instead of
+    /// counting the test twice, which also self-heals a missing end notification.
+    /// </remarks>
+    int RecordTestStart(string? workerId = null);
+
+    /// <summary>
+    /// Signals that the test running on the specified worker has finished, releasing its in-flight slot.
+    /// </summary>
+    /// <param name="workerId">
+    /// Optional worker identifier. Falls back to the current managed thread ID if <see langword="null"/>.
+    /// </param>
+    /// <remarks>
+    /// Call this only after the test's <see cref="CreateExecutionContext"/> record has been built, so
+    /// that the test is counted in its own <see cref="TestOrchestrationRecord.ConcurrentTestCount"/>.
+    /// Calling it for a worker with no test in flight is a no-op, so it is safe to invoke from a
+    /// <c>finally</c> block.
+    /// </remarks>
+    void RecordTestEnd(string? workerId = null);
 
     /// <summary>
     /// Records a completed test so it can be referenced as the previous test in subsequent executions

--- a/src/Xping.Sdk.Core/Services/Collector/Internals/ExecutionTracker.cs
+++ b/src/Xping.Sdk.Core/Services/Collector/Internals/ExecutionTracker.cs
@@ -90,12 +90,12 @@ internal sealed class ExecutionTracker : IExecutionTracker
 
         // Measure actual concurrency. The adapter reports the test end only after this record has
         // been built, so this test is still in flight and counts itself. The slot carries the peak
-        // overlap observed during the test, which covers tests that overlapped and already finished;
-        // the live count is a lower bound for callers that never reported a start.
-        int observedConcurrency = _inFlightTests.TryGetValue(workerKey, out InFlightTest? inFlightTest)
-            ? Volatile.Read(ref inFlightTest.ObservedConcurrency)
-            : 0;
-        int concurrentCount = Math.Max(1, Math.Max(observedConcurrency, _inFlightTests.Count));
+        // overlap observed during the test, which covers tests that overlapped and already finished.
+        // Without a slot for this worker the test's own overlap window is unknown, so report that it
+        // ran alone rather than attributing unrelated in-flight tests to it.
+        int concurrentCount = _inFlightTests.TryGetValue(workerKey, out InFlightTest? inFlightTest)
+            ? Math.Max(1, Volatile.Read(ref inFlightTest.ObservedConcurrency))
+            : 1;
 
         // A local builder: a shared instance would let concurrent workers interleave their
         // Reset()/With...() calls and emit records mixing fields from two different tests.

--- a/src/Xping.Sdk.Core/Services/Collector/Internals/ExecutionTracker.cs
+++ b/src/Xping.Sdk.Core/Services/Collector/Internals/ExecutionTracker.cs
@@ -18,7 +18,12 @@ internal sealed class ExecutionTracker : IExecutionTracker
 {
     private readonly ConcurrentDictionary<string, PrecedingTestRecord> _previousTests = new();
     private readonly ConcurrentDictionary<string, int> _workerPositions = new();
-    private readonly TestOrchestrationBuilder _builder = new();
+
+    // In-flight tests, keyed by worker. Every supported framework runs at most one test per worker
+    // at a time, so the worker key doubles as the in-flight slot: a repeated start replaces the
+    // slot instead of double counting, and a missing end self-heals on the worker's next test.
+    private readonly ConcurrentDictionary<string, InFlightTest> _inFlightTests = new();
+
     private readonly ITimeProvider _timeProvider;
     private int _globalPosition;
     private long _suiteStartTimestamp; // 0 = not yet captured; Stopwatch timestamps are always positive
@@ -33,6 +38,9 @@ internal sealed class ExecutionTracker : IExecutionTracker
 
     /// <inheritdoc/>
     int IExecutionTracker.ActiveWorkerCount => _workerPositions.Count;
+
+    private static string ResolveWorkerKey(string? workerId) =>
+        workerId ?? System.Environment.CurrentManagedThreadId.ToString(CultureInfo.InvariantCulture);
 
     private TimeSpan ComputeSuiteElapsedTime()
     {
@@ -54,7 +62,7 @@ internal sealed class ExecutionTracker : IExecutionTracker
         }
 
         string threadId = System.Environment.CurrentManagedThreadId.ToString(CultureInfo.InvariantCulture);
-        string workerKey = workerId ?? threadId;
+        string workerKey = ResolveWorkerKey(workerId);
 
         int workerPosition;
         int globalPosition;
@@ -80,11 +88,18 @@ internal sealed class ExecutionTracker : IExecutionTracker
         // Get a previous test for this worker
         _previousTests.TryGetValue(workerKey, out PrecedingTestRecord? previousTest);
 
-        // Count active workers (approximation of concurrency)
-        int concurrentCount = _workerPositions.Count;
+        // Measure actual concurrency. The adapter reports the test end only after this record has
+        // been built, so this test is still in flight and counts itself. The slot carries the peak
+        // overlap observed during the test, which covers tests that overlapped and already finished;
+        // the live count is a lower bound for callers that never reported a start.
+        int observedConcurrency = _inFlightTests.TryGetValue(workerKey, out InFlightTest? inFlightTest)
+            ? Volatile.Read(ref inFlightTest.ObservedConcurrency)
+            : 0;
+        int concurrentCount = Math.Max(1, Math.Max(observedConcurrency, _inFlightTests.Count));
 
-        TestOrchestrationRecord testOrchestrationRecord = _builder
-            .Reset()
+        // A local builder: a shared instance would let concurrent workers interleave their
+        // Reset()/With...() calls and emit records mixing fields from two different tests.
+        TestOrchestrationRecord testOrchestrationRecord = new TestOrchestrationBuilder()
             .WithThreadId(threadId)
             .WithWorkerId(workerKey)
             .WithCollectionName(collectionName)
@@ -99,10 +114,52 @@ internal sealed class ExecutionTracker : IExecutionTracker
     }
 
     /// <inheritdoc/>
+    int IExecutionTracker.RecordTestStart(string? workerId)
+    {
+        string workerKey = ResolveWorkerKey(workerId);
+
+        InFlightTest inFlightTest = new();
+        _inFlightTests[workerKey] = inFlightTest;
+
+        int inFlightCount = _inFlightTests.Count;
+
+        // Publish the new concurrency level to every test currently in flight, including this one,
+        // so each test reports the peak overlap it actually experienced rather than the overlap that
+        // happened to exist at the moment its record was built.
+        foreach (KeyValuePair<string, InFlightTest> entry in _inFlightTests)
+        {
+            ObserveConcurrency(entry.Value, inFlightCount);
+        }
+
+        return inFlightCount;
+    }
+
+    /// <inheritdoc/>
+    void IExecutionTracker.RecordTestEnd(string? workerId)
+    {
+        _inFlightTests.TryRemove(ResolveWorkerKey(workerId), out _);
+    }
+
+    private static void ObserveConcurrency(InFlightTest inFlightTest, int concurrency)
+    {
+        int current = Volatile.Read(ref inFlightTest.ObservedConcurrency);
+
+        while (current < concurrency)
+        {
+            int previous = Interlocked.CompareExchange(ref inFlightTest.ObservedConcurrency, concurrency, current);
+            if (previous == current)
+            {
+                return;
+            }
+
+            current = previous;
+        }
+    }
+
+    /// <inheritdoc/>
     void IExecutionTracker.RecordTestCompletion(string? workerId, string testFingerprint, string testName, TestOutcome outcome)
     {
-        string threadId = System.Environment.CurrentManagedThreadId.ToString(CultureInfo.InvariantCulture);
-        string workerKey = workerId ?? threadId;
+        string workerKey = ResolveWorkerKey(workerId);
 
         _previousTests[workerKey] = new PrecedingTestRecord
         {
@@ -115,8 +172,7 @@ internal sealed class ExecutionTracker : IExecutionTracker
     /// <inheritdoc/>
     int IExecutionTracker.GetWorkerPosition(string? workerId)
     {
-        string threadId = System.Environment.CurrentManagedThreadId.ToString(CultureInfo.InvariantCulture);
-        string workerKey = workerId ?? threadId;
+        string workerKey = ResolveWorkerKey(workerId);
 
         return _workerPositions.TryGetValue(workerKey, out int position) ? position : 0;
     }
@@ -124,8 +180,7 @@ internal sealed class ExecutionTracker : IExecutionTracker
     /// <inheritdoc/>
     PrecedingTestRecord? IExecutionTracker.GetPreviousTest(string? workerId)
     {
-        string threadId = System.Environment.CurrentManagedThreadId.ToString(CultureInfo.InvariantCulture);
-        string workerKey = workerId ?? threadId;
+        string workerKey = ResolveWorkerKey(workerId);
 
         return _previousTests.TryGetValue(workerKey, out PrecedingTestRecord? previousTest) ? previousTest : null;
     }
@@ -135,8 +190,20 @@ internal sealed class ExecutionTracker : IExecutionTracker
     {
         _previousTests.Clear();
         _workerPositions.Clear();
+        _inFlightTests.Clear();
         _globalPosition = 0;
         _suiteStartTimestamp = 0;
-        _builder.Reset();
+    }
+
+    /// <summary>
+    /// A test occupying a worker's in-flight slot, carrying the peak concurrency observed while it ran.
+    /// </summary>
+    private sealed class InFlightTest
+    {
+        /// <summary>
+        /// The highest number of tests seen in flight at any point while this test was running.
+        /// Mutated through <see cref="Interlocked"/>, so it cannot be a property.
+        /// </summary>
+        public int ObservedConcurrency;
     }
 }

--- a/src/Xping.Sdk.MSTest/XpingTestBase.cs
+++ b/src/Xping.Sdk.MSTest/XpingTestBase.cs
@@ -30,6 +30,11 @@ public abstract class XpingTestBase
     private DateTime _startTime;
     private long _startTimestamp;
 
+    // Captured in TestInitialize rather than read again in TestCleanup: for an async test method the
+    // cleanup continuation can resume on a different pool thread, which would split the test's start
+    // and end — and its ordering chain — across two worker keys.
+    private string? _workerKey;
+
     // Resolved once on first XpingTestInitialize() call and reused for every cleanup on this instance.
     // The DI singletons are the same each time, so a single resolution per instance is enough.
     private XpingBaseServices _services = null!;
@@ -70,6 +75,19 @@ public abstract class XpingTestBase
 
         _startTime = DateTime.UtcNow;
         _startTimestamp = Stopwatch.GetTimestamp();
+        _workerKey = Environment.CurrentManagedThreadId.ToString(CultureInfo.InvariantCulture);
+
+        try
+        {
+            // Mark the test in flight so the tests it overlaps with can be measured. The matching end
+            // runs in XpingTestCleanup's finally block.
+            _services.ExecutionTracker.RecordTestStart(_workerKey);
+        }
+        catch
+        {
+            // Swallow exceptions to avoid interfering with test execution: _services is unset when
+            // the SDK failed to initialize above.
+        }
     }
 
     /// <summary>
@@ -78,26 +96,46 @@ public abstract class XpingTestBase
     [TestCleanup]
     public void XpingTestCleanup()
     {
-        if (TestContext == null)
-            return;
-
-        var endTimestamp = Stopwatch.GetTimestamp();
-        var endTime = DateTime.UtcNow;
-
-        var elapsedTicks = endTimestamp - _startTimestamp;
-        var duration = TimeSpan.FromTicks(elapsedTicks * TimeSpan.TicksPerSecond / Stopwatch.Frequency);
-
-        var threadId = Environment.CurrentManagedThreadId.ToString(CultureInfo.InvariantCulture);
-        var className = TestContext.FullyQualifiedTestClassName ?? "Unknown";
-
         try
         {
-            var execution = CreateTestExecution(_services, TestContext, _startTime, endTime, duration, threadId, className);
-            XpingContext.RecordTest(execution);
+            if (TestContext == null)
+                return;
+
+            var endTimestamp = Stopwatch.GetTimestamp();
+            var endTime = DateTime.UtcNow;
+
+            var elapsedTicks = endTimestamp - _startTimestamp;
+            var duration = TimeSpan.FromTicks(elapsedTicks * TimeSpan.TicksPerSecond / Stopwatch.Frequency);
+
+            var workerKey = _workerKey ?? Environment.CurrentManagedThreadId.ToString(CultureInfo.InvariantCulture);
+            var className = TestContext.FullyQualifiedTestClassName ?? "Unknown";
+
+            try
+            {
+                var execution = CreateTestExecution(_services, TestContext, _startTime, endTime, duration, workerKey, className);
+                XpingContext.RecordTest(execution);
+            }
+            catch
+            {
+                // Swallow exceptions to avoid interfering with test execution
+            }
         }
-        catch
+        finally
         {
-            // Swallow exceptions to avoid interfering with test execution
+            if (_workerKey != null)
+            {
+                try
+                {
+                    // Release the in-flight slot even when recording failed, so later tests are not
+                    // reported as having run concurrently with this one. Runs after the record above
+                    // was built, so this test still counts itself.
+                    _services.ExecutionTracker.RecordTestEnd(_workerKey);
+                }
+                catch
+                {
+                    // Swallow exceptions to avoid interfering with test execution
+                }
+            }
         }
     }
 
@@ -107,7 +145,7 @@ public abstract class XpingTestBase
         DateTime startTime,
         DateTime endTime,
         TimeSpan duration,
-        string threadId,
+        string workerKey,
         string className)
     {
         var outcome = MapOutcome(context.CurrentTestOutcome);
@@ -157,7 +195,7 @@ public abstract class XpingTestBase
         // Create an execution context using ExecutionTracker.
         // Pass the attempt number so retried executions reuse the position of the first attempt.
         var orchestrationRecord = services.ExecutionTracker.CreateExecutionContext(
-            threadId, className, retryMetadata?.AttemptNumber ?? 1);
+            workerKey, className, retryMetadata?.AttemptNumber ?? 1);
 
         TestMetadata metadata = ExtractMetadata(context);
 
@@ -179,7 +217,7 @@ public abstract class XpingTestBase
             .Build();
 
         // Record test completion for tracking as previous test
-        services.ExecutionTracker.RecordTestCompletion(threadId, identity.TestFingerprint, testName, outcome);
+        services.ExecutionTracker.RecordTestCompletion(workerKey, identity.TestFingerprint, testName, outcome);
 
         return execution;
     }

--- a/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
+++ b/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
@@ -87,6 +87,21 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
 
         test.Properties.Set(StartTimeKey, startTime);
         test.Properties.Set(StartTimestampKey, startTimestamp);
+
+        try
+        {
+            // Mark the test in flight so the tests it overlaps with can be measured. Reported under
+            // the same worker key AfterTest uses, so the start and end pair up. No per-test state is
+            // needed here: the tracker keys in-flight tests by worker, so applying [XpingTrack] at
+            // several scopes at once (which invokes BeforeTest once per attribute instance) cannot
+            // inflate the count.
+            _services.ExecutionTracker.RecordTestStart(TestContext.CurrentContext.WorkerId);
+        }
+        catch
+        {
+            // Swallow exceptions to avoid interfering with test execution: _services is unset when
+            // the SDK failed to initialize above.
+        }
     }
 
     /// <summary>
@@ -137,6 +152,20 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
         catch
         {
             // Swallow exceptions to avoid interfering with test execution
+        }
+        finally
+        {
+            try
+            {
+                // Release the in-flight slot even when recording failed, so later tests are not
+                // reported as having run concurrently with this one. Runs after the record above was
+                // built, so this test still counts itself.
+                _services.ExecutionTracker.RecordTestEnd(TestContext.CurrentContext.WorkerId);
+            }
+            catch
+            {
+                // Swallow exceptions to avoid interfering with test execution
+            }
         }
     }
 

--- a/src/Xping.Sdk.XUnit/XpingMessageSink.cs
+++ b/src/Xping.Sdk.XUnit/XpingMessageSink.cs
@@ -40,7 +40,6 @@ public sealed class XpingMessageSink(
     private readonly string _assemblyName = assemblyName.RequireNotNull();
 
     private readonly ConcurrentDictionary<string, TestExecutionData> _testData = new();
-    private readonly ConcurrentDictionary<string, int> _activeCollections = new();
 
     /// <summary>
     /// Handles incoming messages from xUnit test execution.
@@ -83,9 +82,6 @@ public sealed class XpingMessageSink(
         string testKey = GetTestKey(testStarting.Test);
         string? collectionName = testStarting.Test.TestCase.TestMethod.TestClass.TestCollection.DisplayName;
 
-        // Track active collections for parallelization detection
-        _activeCollections.AddOrUpdate(collectionName, 1, (_, count) => count + 1);
-
         TestExecutionData data = new()
         {
             Test = testStarting.Test,
@@ -94,7 +90,13 @@ public sealed class XpingMessageSink(
             CollectionName = collectionName,
         };
 
-        _testData.TryAdd(testKey, data);
+        if (_testData.TryAdd(testKey, data))
+        {
+            // Mark the test in flight so overlapping tests can be measured. Reported only when the
+            // entry was added, so it pairs with the TryRemove in the result handlers; the matching
+            // end runs in RecordTestExecution's finally block.
+            _executionTracker.RecordTestStart(collectionName);
+        }
     }
 
     private void HandleTestPassed(ITestPassed testPassed)
@@ -221,6 +223,12 @@ public sealed class XpingMessageSink(
         catch
         {
             // Swallow exceptions to avoid interfering with test execution
+        }
+        finally
+        {
+            // Release the in-flight slot even when record creation failed, so later tests are not
+            // reported as having run concurrently with this one.
+            _executionTracker.RecordTestEnd(collectionName);
         }
     }
 

--- a/tests/Xping.Sdk.Core.Tests/Collection/ExecutionTrackerTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Collection/ExecutionTrackerTests.cs
@@ -136,21 +136,6 @@ public sealed class ExecutionTrackerTests
     }
 
     [Fact]
-    public void CreateExecutionContext_ShouldDetectParallelism_WhenMultipleWorkers()
-    {
-        // Arrange
-        var tracker = BuildTracker();
-
-        // Act — register two workers at the same time
-        tracker.CreateExecutionContext("worker-a");
-        var record = tracker.CreateExecutionContext("worker-b");
-
-        // Assert — ConcurrentTestCount should be 2 (two workers active)
-        Assert.Equal(2, record.ConcurrentTestCount);
-        Assert.True(record.WasParallelized);
-    }
-
-    [Fact]
     public void CreateExecutionContext_ShouldUseCollectionName_WhenProvided()
     {
         // Arrange
@@ -262,6 +247,259 @@ public sealed class ExecutionTrackerTests
     }
 
     // ---------------------------------------------------------------------------
+    // Parallelization (issue #120)
+    //
+    // WasParallelized/ConcurrentTestCount used to be derived from the number of distinct
+    // worker keys ever seen, which is monotonically non-decreasing and says nothing about
+    // concurrency. They are now measured from RecordTestStart/RecordTestEnd notifications.
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void CreateExecutionContext_SerialExecutionAcrossWorkers_ShouldNotReportParallelization()
+    {
+        // Regression for #120: a serial run that visits several workers (xUnit reports one
+        // collection per test class) must not be reported as parallel.
+        // Arrange
+        var tracker = BuildTracker();
+
+        // Act — one test at a time, each fully finished before the next starts
+        tracker.RecordTestStart("worker-a");
+        var first = tracker.CreateExecutionContext("worker-a");
+        tracker.RecordTestEnd("worker-a");
+
+        tracker.RecordTestStart("worker-b");
+        var second = tracker.CreateExecutionContext("worker-b");
+        tracker.RecordTestEnd("worker-b");
+
+        // Assert
+        Assert.Equal(1, first.ConcurrentTestCount);
+        Assert.False(first.WasParallelized);
+        Assert.Equal(1, second.ConcurrentTestCount);
+        Assert.False(second.WasParallelized);
+    }
+
+    [Fact]
+    public void CreateExecutionContext_OverlappingTests_ShouldReportBothAsParallel()
+    {
+        // Arrange
+        var tracker = BuildTracker();
+
+        // Act — both tests are in flight at the same time
+        tracker.RecordTestStart("worker-a");
+        tracker.RecordTestStart("worker-b");
+
+        var recordA = tracker.CreateExecutionContext("worker-a");
+        var recordB = tracker.CreateExecutionContext("worker-b");
+
+        // Assert — overlapping tests agree on the count, so a session's records stay consistent
+        Assert.Equal(2, recordA.ConcurrentTestCount);
+        Assert.True(recordA.WasParallelized);
+        Assert.Equal(2, recordB.ConcurrentTestCount);
+        Assert.True(recordB.WasParallelized);
+    }
+
+    [Fact]
+    public void CreateExecutionContext_OverlapEndedBeforeRecordCreated_ShouldReportPeak()
+    {
+        // ConcurrentTestCount is the peak overlap during the test, not a snapshot taken when
+        // the record is built — worker-b has already finished by the time worker-a reports.
+        // Arrange
+        var tracker = BuildTracker();
+
+        // Act
+        tracker.RecordTestStart("worker-a");
+        tracker.RecordTestStart("worker-b");
+        tracker.RecordTestEnd("worker-b");
+
+        var record = tracker.CreateExecutionContext("worker-a");
+
+        // Assert
+        Assert.Equal(2, record.ConcurrentTestCount);
+        Assert.True(record.WasParallelized);
+    }
+
+    [Fact]
+    public void CreateExecutionContext_WithoutRecordedStart_ShouldReportSingleTest()
+    {
+        // Callers that never report test starts (third-party integrations) get the honest
+        // default rather than a fabricated concurrency value.
+        // Arrange
+        var tracker = BuildTracker();
+
+        // Act
+        var record = tracker.CreateExecutionContext("worker-a");
+
+        // Assert
+        Assert.Equal(1, record.ConcurrentTestCount);
+        Assert.False(record.WasParallelized);
+    }
+
+    [Fact]
+    public void RecordTestStart_CalledTwiceForSameWorker_ShouldNotDoubleCount()
+    {
+        // [XpingTrack] can be applied at assembly, class and method scope at once, in which case
+        // NUnit invokes BeforeTest once per attribute instance for the same test.
+        // Arrange
+        var tracker = BuildTracker();
+
+        // Act
+        tracker.RecordTestStart("worker-a");
+        tracker.RecordTestStart("worker-a");
+        var record = tracker.CreateExecutionContext("worker-a");
+
+        // Assert
+        Assert.Equal(1, record.ConcurrentTestCount);
+        Assert.False(record.WasParallelized);
+    }
+
+    [Fact]
+    public void RecordTestEnd_WithoutMatchingStart_ShouldBeNoOp()
+    {
+        // Adapters call RecordTestEnd from a finally block, which can run without a matching start
+        // (e.g. when initialization failed before the test was registered).
+        // Arrange
+        var tracker = BuildTracker();
+
+        // Act
+        tracker.RecordTestEnd("worker-a");
+        tracker.RecordTestEnd("worker-a");
+        tracker.RecordTestEnd("worker-b");
+
+        tracker.RecordTestStart("worker-a");
+        var record = tracker.CreateExecutionContext("worker-a");
+
+        // Assert — no underflow leaked into the next test
+        Assert.Equal(1, record.ConcurrentTestCount);
+        Assert.False(record.WasParallelized);
+    }
+
+    [Fact]
+    public void RecordTestStart_AfterAbandonedTest_ShouldSelfHealOnSameWorker()
+    {
+        // A test whose end is never reported (framework abort) must not leave the worker
+        // permanently occupied — otherwise every later test looks parallel, which is #120 again.
+        // Arrange
+        var tracker = BuildTracker();
+        tracker.RecordTestStart("worker-a"); // abandoned: no RecordTestEnd
+
+        // Act
+        tracker.RecordTestStart("worker-a");
+        var record = tracker.CreateExecutionContext("worker-a");
+
+        // Assert
+        Assert.Equal(1, record.ConcurrentTestCount);
+        Assert.False(record.WasParallelized);
+    }
+
+    [Fact]
+    public void RecordTestStart_AbandonedOtherWorker_ShouldStillCount()
+    {
+        // Accepted residual behavior: a lost end on a worker that never runs another test keeps
+        // its slot for the rest of the run, so tests on other workers see it as an overlap.
+        // Encoded here so the trade-off cannot drift silently.
+        // Arrange
+        var tracker = BuildTracker();
+        tracker.RecordTestStart("worker-a"); // abandoned: no RecordTestEnd
+
+        // Act
+        tracker.RecordTestStart("worker-b");
+        var record = tracker.CreateExecutionContext("worker-b");
+
+        // Assert
+        Assert.Equal(2, record.ConcurrentTestCount);
+        Assert.True(record.WasParallelized);
+    }
+
+    [Fact]
+    public void RecordTestStart_NullWorkerId_ShouldPairWithThreadIdFallback()
+    {
+        // Arrange — serial NUnit runs report a null WorkerId, so both sides fall back to the thread id
+        var tracker = BuildTracker();
+
+        // Act
+        tracker.RecordTestStart();
+        var record = tracker.CreateExecutionContext();
+        tracker.RecordTestEnd();
+
+        // Assert
+        Assert.Equal(1, record.ConcurrentTestCount);
+        Assert.False(record.WasParallelized);
+    }
+
+    [Fact]
+    public void RecordTestStart_ShouldReturnNumberOfTestsInFlight()
+    {
+        // Arrange
+        var tracker = BuildTracker();
+
+        // Act & Assert
+        Assert.Equal(1, tracker.RecordTestStart("worker-a"));
+        Assert.Equal(2, tracker.RecordTestStart("worker-b"));
+
+        tracker.RecordTestEnd("worker-a");
+
+        Assert.Equal(2, tracker.RecordTestStart("worker-c"));
+    }
+
+    [Fact]
+    public void CreateExecutionContext_ConcurrentCalls_ShouldReportEveryTestAsParallel()
+    {
+        // Arrange
+        const int workerCount = 8;
+        var tracker = BuildTracker();
+        var records = new ConcurrentBag<TestOrchestrationRecord>();
+        using var allStarted = new Barrier(workerCount);
+
+        // Act — every worker registers its start, then all of them build their records
+        Parallel.For(0, workerCount, index =>
+        {
+            string workerId = $"worker-{index}";
+
+            tracker.RecordTestStart(workerId);
+            allStarted.SignalAndWait();
+
+            records.Add(tracker.CreateExecutionContext(workerId));
+            tracker.RecordTestEnd(workerId);
+        });
+
+        // Assert — all eight overlapped, so all eight report the full peak
+        Assert.Equal(workerCount, records.Count);
+        Assert.All(records, record =>
+        {
+            Assert.Equal(workerCount, record.ConcurrentTestCount);
+            Assert.True(record.WasParallelized);
+        });
+    }
+
+    [Fact]
+    public void CreateExecutionContext_ConcurrentCalls_ShouldNotProduceMixedRecords()
+    {
+        // Regression for the shared TestOrchestrationBuilder: concurrent callers used to interleave
+        // their Reset()/With...() calls on one instance and emit records mixing two tests' fields.
+        // This is a probabilistic detector — intermittent against the old code, always green now.
+        // Arrange
+        const int workerCount = 16;
+        var tracker = BuildTracker();
+        var records = new ConcurrentBag<TestOrchestrationRecord>();
+
+        // Act — worker and collection names are paired, so a mixed record shows up as a mismatch
+        Parallel.For(0, workerCount, index =>
+        {
+            var record = tracker.CreateExecutionContext($"worker-{index}", $"collection-{index}");
+            records.Add(record);
+        });
+
+        // Assert
+        Assert.Equal(workerCount, records.Count);
+        Assert.All(records, record =>
+        {
+            string index = record.WorkerId.Substring("worker-".Length);
+            Assert.Equal($"collection-{index}", record.CollectionName);
+            Assert.Equal(1, record.PositionInSuite); // each worker ran exactly one test
+        });
+    }
+
+    // ---------------------------------------------------------------------------
     // ActiveWorkerCount
     // ---------------------------------------------------------------------------
 
@@ -318,6 +556,25 @@ public sealed class ExecutionTrackerTests
         // Assert
         Assert.Equal(1, record.PositionInSuite);
         Assert.Equal(1, tracker.GlobalPosition);
+    }
+
+    [Fact]
+    public void Clear_ShouldResetInFlightState()
+    {
+        // Arrange — two tests left in flight when the suite state is released
+        var tracker = BuildTracker();
+        tracker.RecordTestStart("w1");
+        tracker.RecordTestStart("w2");
+
+        // Act
+        tracker.Clear();
+
+        tracker.RecordTestStart("w3");
+        var record = tracker.CreateExecutionContext("w3");
+
+        // Assert — the abandoned slots do not survive the reset
+        Assert.Equal(1, record.ConcurrentTestCount);
+        Assert.False(record.WasParallelized);
     }
 
     // ---------------------------------------------------------------------------

--- a/tests/Xping.Sdk.Core.Tests/Collection/ExecutionTrackerTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Collection/ExecutionTrackerTests.cs
@@ -335,6 +335,24 @@ public sealed class ExecutionTrackerTests
     }
 
     [Fact]
+    public void CreateExecutionContext_WithoutRecordedStart_ShouldReportSingleTestWhileOthersAreInFlight()
+    {
+        // A caller that does not report starts has no measurable overlap window of its own, so
+        // tests in flight on other workers must not be attributed to it.
+        // Arrange
+        var tracker = BuildTracker();
+        tracker.RecordTestStart("worker-a");
+        tracker.RecordTestStart("worker-b");
+
+        // Act
+        var record = tracker.CreateExecutionContext("worker-untracked");
+
+        // Assert
+        Assert.Equal(1, record.ConcurrentTestCount);
+        Assert.False(record.WasParallelized);
+    }
+
+    [Fact]
     public void RecordTestStart_CalledTwiceForSameWorker_ShouldNotDoubleCount()
     {
         // [XpingTrack] can be applied at assembly, class and method scope at once, in which case

--- a/tests/Xping.Sdk.XUnit.Tests/XpingMessageSinkConcurrencyTests.cs
+++ b/tests/Xping.Sdk.XUnit.Tests/XpingMessageSinkConcurrencyTests.cs
@@ -1,0 +1,232 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit.Abstractions;
+using Xping.Sdk.Core.Extensions;
+using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.Core.Services.Collector;
+using Xping.Sdk.Core.Services.Identity;
+using Xping.Sdk.Core.Services.Retry;
+
+namespace Xping.Sdk.XUnit.Tests;
+
+/// <summary>
+/// Regression tests for issue #120: parallelization used to be derived from the number of distinct
+/// test collections seen so far, so every xUnit run with more than one test class reported
+/// <c>WasParallelized = true</c> even when collection parallelization was disabled.
+/// </summary>
+[Collection("XpingContext")]
+public sealed class XpingMessageSinkConcurrencyTests : IAsyncLifetime
+{
+    // Keep the shared XpingContext singleton shut down: the sink records every execution it builds
+    // through XpingContext.RecordTest, and a live session would collect these fakes and try to
+    // upload them (swallowed, but slow). The orchestration records are captured before that call.
+    public Task InitializeAsync() => XpingContext.ShutdownAsync().AsTask();
+
+    public Task DisposeAsync() => XpingContext.ShutdownAsync().AsTask();
+
+    [Fact]
+    public void Serial_TwoTestsInDifferentCollections_ShouldNotReportParallelization()
+    {
+        // Arrange
+        (XpingMessageSink sink, RecordingExecutionTracker tracker) = CreateSink();
+        ITest testA = BuildFakeTest("test-a", "CalculatorTests.Add", "SampleApp.XUnit.CalculatorTests");
+        ITest testB = BuildFakeTest("test-b", "StringTests.Trim", "SampleApp.XUnit.StringTests");
+
+        // Act — each test finishes before the next one starts
+        Send(sink, Starting(testA));
+        Send(sink, Passed(testA));
+        Send(sink, Starting(testB));
+        Send(sink, Passed(testB));
+
+        // Assert
+        Assert.Equal(2, tracker.Records.Count);
+        Assert.All(tracker.Records, record =>
+        {
+            Assert.Equal(1, record.ConcurrentTestCount);
+            Assert.False(record.WasParallelized);
+        });
+    }
+
+    [Fact]
+    public void Overlapping_TwoCollections_ShouldReportParallelization()
+    {
+        // Arrange
+        (XpingMessageSink sink, RecordingExecutionTracker tracker) = CreateSink();
+        ITest testA = BuildFakeTest("test-a", "CalculatorTests.Add", "SampleApp.XUnit.CalculatorTests");
+        ITest testB = BuildFakeTest("test-b", "StringTests.Trim", "SampleApp.XUnit.StringTests");
+
+        // Act — both collections are in flight at the same time
+        Send(sink, Starting(testA));
+        Send(sink, Starting(testB));
+        Send(sink, Passed(testA));
+        Send(sink, Passed(testB));
+
+        // Assert
+        Assert.Equal(2, tracker.Records.Count);
+        Assert.All(tracker.Records, record =>
+        {
+            Assert.Equal(2, record.ConcurrentTestCount);
+            Assert.True(record.WasParallelized);
+        });
+    }
+
+    private static void Send(XpingMessageSink sink, IMessageSinkMessage message) =>
+        ((IMessageSink)sink).OnMessage(message);
+
+    /// <summary>
+    /// Builds a sink backed by the real <see cref="IExecutionTracker"/> implementation, wrapped so the
+    /// orchestration records it produces can be inspected.
+    /// </summary>
+    private static (XpingMessageSink sink, RecordingExecutionTracker tracker) CreateSink()
+    {
+        IExecutionTracker inner = new ServiceCollection()
+            .AddXpingCollectors()
+            .BuildServiceProvider()
+            .GetRequiredService<IExecutionTracker>();
+
+        RecordingExecutionTracker tracker = new(inner);
+
+        var identityGenerator = new Mock<ITestIdentityGenerator>();
+        identityGenerator
+            .Setup(g => g.Generate(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<object[]?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>(),
+                It.IsAny<string?>()))
+            .Returns(new TestIdentity());
+
+        XpingMessageSink sink = new(
+            Mock.Of<IMessageSink>(),
+            tracker,
+            new Mock<IRetryDetector<ITest>>().Object,
+            identityGenerator.Object,
+            NullLogger<XpingMessageSink>.Instance,
+            captureStackTraces: true,
+            assemblyName: "SampleApp.XUnit");
+
+        return (sink, tracker);
+    }
+
+    private static ITestStarting Starting(ITest test)
+    {
+        var message = new Mock<ITestStarting>();
+        message.SetupGet(m => m.Test).Returns(test);
+        return message.Object;
+    }
+
+    private static ITestPassed Passed(ITest test)
+    {
+        var message = new Mock<ITestPassed>();
+        message.SetupGet(m => m.Test).Returns(test);
+        message.SetupGet(m => m.ExecutionTime).Returns(0.01m);
+        message.SetupGet(m => m.Output).Returns(string.Empty);
+        return message.Object;
+    }
+
+    /// <summary>
+    /// Builds a fake xUnit <see cref="ITest"/> carrying the members the sink reads: the unique ID it
+    /// keys pending tests by, and the collection display name it uses as the worker identifier.
+    /// </summary>
+    private static ITest BuildFakeTest(string uniqueId, string displayName, string collectionName)
+    {
+        var assemblyInfo = new Mock<IAssemblyInfo>();
+        assemblyInfo.SetupGet(a => a.Name).Returns("SampleApp.XUnit");
+
+        var classInfo = new Mock<ITypeInfo>();
+        classInfo.SetupGet(c => c.Name).Returns(collectionName);
+        classInfo.SetupGet(c => c.Assembly).Returns(assemblyInfo.Object);
+
+        var methodInfo = new Mock<IMethodInfo>();
+        methodInfo.SetupGet(m => m.Name).Returns(displayName);
+        methodInfo.SetupGet(m => m.Type).Returns(classInfo.Object);
+
+        var testCollection = new Mock<ITestCollection>();
+        testCollection.SetupGet(c => c.DisplayName).Returns(collectionName);
+
+        var testClass = new Mock<ITestClass>();
+        testClass.SetupGet(c => c.Class).Returns(classInfo.Object);
+        testClass.SetupGet(c => c.TestCollection).Returns(testCollection.Object);
+
+        var testMethod = new Mock<ITestMethod>();
+        testMethod.SetupGet(m => m.Method).Returns(methodInfo.Object);
+        testMethod.SetupGet(m => m.TestClass).Returns(testClass.Object);
+
+        var testCase = new Mock<ITestCase>();
+        testCase.SetupGet(c => c.TestMethod).Returns(testMethod.Object);
+        testCase.SetupGet(c => c.UniqueID).Returns(uniqueId);
+        testCase.SetupGet(c => c.DisplayName).Returns(displayName);
+
+        var test = new Mock<ITest>();
+        test.SetupGet(t => t.TestCase).Returns(testCase.Object);
+        test.SetupGet(t => t.DisplayName).Returns(displayName);
+
+        return test.Object;
+    }
+
+    /// <summary>
+    /// Delegates to a real <see cref="IExecutionTracker"/> while capturing every orchestration record
+    /// it hands back, in the order the sink requested them.
+    /// </summary>
+    private sealed class RecordingExecutionTracker : IExecutionTracker
+    {
+        private readonly IExecutionTracker _inner;
+        private readonly List<TestOrchestrationRecord> _records = [];
+
+        public RecordingExecutionTracker(IExecutionTracker inner)
+        {
+            _inner = inner;
+        }
+
+        public IReadOnlyList<TestOrchestrationRecord> Records
+        {
+            get
+            {
+                lock (_records)
+                {
+                    return [.. _records];
+                }
+            }
+        }
+
+        public int GlobalPosition => _inner.GlobalPosition;
+
+        public int ActiveWorkerCount => _inner.ActiveWorkerCount;
+
+        public TestOrchestrationRecord CreateExecutionContext(
+            string? workerId = null,
+            string? collectionName = null,
+            int attemptNumber = 1)
+        {
+            TestOrchestrationRecord record = _inner.CreateExecutionContext(workerId, collectionName, attemptNumber);
+
+            lock (_records)
+            {
+                _records.Add(record);
+            }
+
+            return record;
+        }
+
+        public int RecordTestStart(string? workerId = null) => _inner.RecordTestStart(workerId);
+
+        public void RecordTestEnd(string? workerId = null) => _inner.RecordTestEnd(workerId);
+
+        public void RecordTestCompletion(string? workerId, string testFingerprint, string testName, TestOutcome outcome) =>
+            _inner.RecordTestCompletion(workerId, testFingerprint, testName, outcome);
+
+        public int GetWorkerPosition(string? workerId = null) => _inner.GetWorkerPosition(workerId);
+
+        public PrecedingTestRecord? GetPreviousTest(string? workerId = null) => _inner.GetPreviousTest(workerId);
+
+        public void Clear() => _inner.Clear();
+    }
+}


### PR DESCRIPTION
ExecutionTracker derived both fields from _workerPositions.Count, which is append-only and therefore counts distinct worker keys ever seen rather than tests in flight. In xUnit (worker key = collection name) the flag flipped true permanently at the second test class even with parallelization disabled; in NUnit and MSTest the constant serial worker key made it always false, correct only by accident.

The tracker now keeps in-flight tests keyed by worker, reported through two new IExecutionTracker members, RecordTestStart and RecordTestEnd. Every supported framework runs at most one test per worker at a time, so the worker key doubles as the in-flight slot: a repeated start replaces the slot instead of double counting, a stray end is a no-op, and a lost end self-heals on that worker's next test. Each slot carries the peak overlap observed while its test ran, so ConcurrentTestCount is that peak (at least 1, including the test itself) and WasParallelized is peak > 1. CreateExecutionContext keeps its signature, so callers that do not report starts still get 1/false.

Also fixes an adjacent race in the same method: the single mutable TestOrchestrationBuilder field let concurrent workers interleave their Reset()/With...() calls and emit records mixing two tests' fields. Each call now builds with a local builder.

Adapters report the start at their existing pre-test hook and release the slot in a finally, after the record is built so the test counts itself:

- xUnit: start only when _testData.TryAdd succeeds, so it pairs with the TryRemove the result handlers already require; end in RecordTestExecution. Removes the dead write-only _activeCollections field.
- NUnit: BeforeTest/AfterTest, both guarded so tracking can never fail a test.
- MSTest: TestInitialize/TestCleanup, with the worker key captured at init time and reused for the record and completion, because an async test's cleanup continuation can resume on a different pool thread.

Verified end to end against a local capture endpoint: xUnit with collection parallelization disabled now reports 1/false for all 12 executions (previously 11 of 12 were marked parallel), while parallel NUnit and MSTest runs report per-test peaks that decay as the run winds down.