### PR TITLE
Fix xUnit adapter to correctly record collection name

### DIFF
--- a/src/Xping.Sdk.XUnit/XpingMessageSink.cs
+++ b/src/Xping.Sdk.XUnit/XpingMessageSink.cs
@@ -276,7 +276,9 @@ public sealed class XpingMessageSink(
         // the concurrency worker key and the record's collection metadata.
         // Pass the attempt number so retried executions reuse the position of the first attempt.
         TestOrchestrationRecord orchestrationRecord = _executionTracker.CreateExecutionContext(
-            workerId: collectionName, collectionName: collectionName, attemptNumber: retryMetadata?.AttemptNumber ?? 1);
+            workerId: collectionName,
+            collectionName: collectionName,
+            attemptNumber: retryMetadata?.AttemptNumber ?? 1);
 
         TestExecution testExecution = new TestExecutionBuilder()
             .WithExecutionId(Guid.NewGuid())

--- a/src/Xping.Sdk.XUnit/XpingMessageSink.cs
+++ b/src/Xping.Sdk.XUnit/XpingMessageSink.cs
@@ -272,10 +272,11 @@ public sealed class XpingMessageSink(
         // Detect retry metadata first, so the attempt number is available when claiming a position.
         RetryMetadata? retryMetadata = _retryDetector.DetectRetryMetadata(test, outcome);
         (string? configuredStackTrace, bool stackTraceOmitted) = ResolveStackTrace(outcome, stackTrace, captureStackTraces);
-        // Create execution context using collection name as worker ID.
+        // xUnit has no separate worker concept, so the collection name doubles as both
+        // the concurrency worker key and the record's collection metadata.
         // Pass the attempt number so retried executions reuse the position of the first attempt.
         TestOrchestrationRecord orchestrationRecord = _executionTracker.CreateExecutionContext(
-            workerId: collectionName, attemptNumber: retryMetadata?.AttemptNumber ?? 1);
+            workerId: collectionName, collectionName: collectionName, attemptNumber: retryMetadata?.AttemptNumber ?? 1);
 
         TestExecution testExecution = new TestExecutionBuilder()
             .WithExecutionId(Guid.NewGuid())

--- a/tests/Xping.Sdk.XUnit.Tests/XpingMessageSinkConcurrencyTests.cs
+++ b/tests/Xping.Sdk.XUnit.Tests/XpingMessageSinkConcurrencyTests.cs
@@ -94,7 +94,6 @@ public sealed class XpingMessageSinkConcurrencyTests : IAsyncLifetime
         // Assert
         TestOrchestrationRecord record = Assert.Single(tracker.Records);
         Assert.Equal("SampleApp.XUnit.CalculatorTests", record.CollectionName);
-        Assert.Equal("SampleApp.XUnit.CalculatorTests", record.WorkerId);
     }
 
     private static void Send(XpingMessageSink sink, IMessageSinkMessage message) =>

--- a/tests/Xping.Sdk.XUnit.Tests/XpingMessageSinkConcurrencyTests.cs
+++ b/tests/Xping.Sdk.XUnit.Tests/XpingMessageSinkConcurrencyTests.cs
@@ -76,6 +76,27 @@ public sealed class XpingMessageSinkConcurrencyTests : IAsyncLifetime
         });
     }
 
+    [Fact]
+    public void RecordExecution_ShouldPopulateCollectionName()
+    {
+        // Regression test for issue #121: the xUnit adapter passed the collection name as the
+        // execution context's worker ID but never as its collection name, leaving
+        // TestOrchestrationRecord.CollectionName null.
+
+        // Arrange
+        (XpingMessageSink sink, RecordingExecutionTracker tracker) = CreateSink();
+        ITest testA = BuildFakeTest("test-a", "CalculatorTests.Add", "SampleApp.XUnit.CalculatorTests");
+
+        // Act
+        Send(sink, Starting(testA));
+        Send(sink, Passed(testA));
+
+        // Assert
+        TestOrchestrationRecord record = Assert.Single(tracker.Records);
+        Assert.Equal("SampleApp.XUnit.CalculatorTests", record.CollectionName);
+        Assert.Equal("SampleApp.XUnit.CalculatorTests", record.WorkerId);
+    }
+
     private static void Send(XpingMessageSink sink, IMessageSinkMessage message) =>
         ((IMessageSink)sink).OnMessage(message);
 


### PR DESCRIPTION
The xUnit adapter previously passed the collection name only as the worker ID, resulting in `TestOrchestrationRecord.CollectionName` being null. This update ensures that the collection name is now passed correctly to `CreateExecutionContext`, allowing it to be recorded accurately. A regression test has been added to verify that the collection name is populated as expected.

Fixes #121