### PR TITLE
Fix #124: add process-exit safety net for MSTest session finalization

### DIFF
--- a/src/Xping.Sdk.MSTest/XpingAssemblyInitialize.cs
+++ b/src/Xping.Sdk.MSTest/XpingAssemblyInitialize.cs
@@ -7,7 +7,6 @@ namespace Xping.Sdk.MSTest;
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Xping.Sdk.Core.Exceptions;
 
 /// <summary>
 /// Assembly-level initialization and cleanup for Xping SDK in MSTest projects.
@@ -33,21 +32,15 @@ public static class XpingAssemblyInitialize
     /// Called once after all tests in the assembly complete.
     /// Finalizes the session by uploading all buffered executions, then disposes SDK resources.
     /// </summary>
+    /// <remarks>
+    /// MSTest does not reliably invoke this hook under some configurations (e.g. method-level
+    /// parallelization — see issue #124). <see cref="XpingContext"/> registers a process-exit safety
+    /// net on <see cref="XpingContext.Initialize()"/> that finalizes the session in that case, so this
+    /// hook is the primary path, not the only one.
+    /// </remarks>
     [AssemblyCleanup]
     public static async Task AssemblyCleanup()
     {
-        try
-        {
-            await XpingContext.FinalizeAsync().ConfigureAwait(false);
-        }
-        catch (XpingNetworkException ex)
-        {
-            // FailFast aborts the process immediately, which is the correct behavior for strict mode
-            // where observability must be guaranteed. Re-throwing from AssemblyCleanup may not cause
-            // the CI pipeline to fail with a non-zero exit code.
-            Environment.FailFast($"[Xping] {ex.Message}", ex);
-        }
-
-        await XpingContext.ShutdownAsync().ConfigureAwait(false);
+        await XpingContext.FinalizeAndShutdownAsync().ConfigureAwait(false);
     }
 }

--- a/src/Xping.Sdk.MSTest/XpingContext.cs
+++ b/src/Xping.Sdk.MSTest/XpingContext.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Xping.Sdk.Core;
 using Xping.Sdk.Core.Configuration;
+using Xping.Sdk.Core.Exceptions;
 using Xping.Sdk.Core.Models.Executions;
 using Xping.Sdk.Core.Models.Statistics;
 using Xping.Sdk.Core.Services.Collector;
@@ -28,6 +29,7 @@ namespace Xping.Sdk.MSTest;
 public class XpingContext : XpingContextOrchestrator
 {
     private static Lazy<XpingContext>? _instance;
+    private static int _processExitHandlerRegistered;
     private readonly ILogger<XpingContext> _logger;
 
     /// <summary>
@@ -61,6 +63,8 @@ public class XpingContext : XpingContextOrchestrator
     /// </summary>
     public static void Initialize()
     {
+        EnsureProcessExitSafetyNetRegistered();
+
         if (IsInitialized)
             return;
 
@@ -77,6 +81,8 @@ public class XpingContext : XpingContextOrchestrator
     /// <param name="configuration">The configuration to use.</param>
     public static void Initialize(XpingConfiguration configuration)
     {
+        EnsureProcessExitSafetyNetRegistered();
+
         if (IsInitialized)
             return;
 
@@ -145,6 +151,67 @@ public class XpingContext : XpingContextOrchestrator
             return Task.CompletedTask;
 
         return _instance.Value.FinalizeSessionAsync(CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Finalizes the Xping session and shuts down the context, matching the behavior MSTest's
+    /// <c>[AssemblyCleanup]</c> hook needs: uploads buffered executions, fails the process fast on a
+    /// strict-mode network error, and always releases the underlying host afterward.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task FinalizeAndShutdownAsync()
+    {
+        try
+        {
+            await FinalizeAsync().ConfigureAwait(false);
+        }
+        catch (XpingNetworkException ex)
+        {
+            // FailFast aborts the process immediately, which is the correct behavior for strict mode
+            // where observability must be guaranteed. Re-throwing here may not cause the CI pipeline
+            // to fail with a non-zero exit code.
+            Environment.FailFast($"[Xping] {ex.Message}", ex);
+        }
+
+        await ShutdownAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Registers a process-exit safety net, once per process, that finalizes an initialized-but-not-yet-
+    /// finalized session. MSTest skips <c>[AssemblyCleanup]</c> under some configurations (e.g. method-
+    /// level parallelization — see issue #124), which otherwise silently discards every buffered
+    /// execution. No-op when a session already finalized normally, since <see cref="ShutdownAsync"/>
+    /// nulls out <see cref="_instance"/> before the process exits.
+    /// </summary>
+    private static void EnsureProcessExitSafetyNetRegistered()
+    {
+        if (Interlocked.CompareExchange(ref _processExitHandlerRegistered, 1, 0) != 0)
+            return;
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => FinalizeOnProcessExit();
+    }
+
+    private static void FinalizeOnProcessExit()
+    {
+        Lazy<XpingContext>? instance = _instance;
+        if (instance is not { IsValueCreated: true })
+            return;
+
+        XpingContext context = instance.Value;
+        context._logger.LogWarning(
+            "[Xping] Process exiting with session {SessionId} still active. The test framework's " +
+            "assembly cleanup hook did not run (e.g. MSTest with method-level parallelization). " +
+            "Finalizing now as a safety net.",
+            context.SessionId);
+
+        try
+        {
+            FinalizeAndShutdownAsync().GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            context._logger.LogError(ex, "[Xping] Error finalizing Xping session during process-exit safety net");
+        }
     }
 
     /// <summary>

--- a/src/Xping.Sdk.MSTest/XpingContext.cs
+++ b/src/Xping.Sdk.MSTest/XpingContext.cs
@@ -163,17 +163,24 @@ public class XpingContext : XpingContextOrchestrator
     {
         try
         {
-            await FinalizeAsync().ConfigureAwait(false);
+            try
+            {
+                await FinalizeAsync().ConfigureAwait(false);
+            }
+            catch (XpingNetworkException ex)
+            {
+                // FailFast aborts the process immediately, which is the correct behavior for strict mode
+                // where observability must be guaranteed. Re-throwing here may not cause the CI pipeline
+                // to fail with a non-zero exit code.
+                Environment.FailFast($"[Xping] {ex.Message}", ex);
+            }
         }
-        catch (XpingNetworkException ex)
+        finally
         {
-            // FailFast aborts the process immediately, which is the correct behavior for strict mode
-            // where observability must be guaranteed. Re-throwing here may not cause the CI pipeline
-            // to fail with a non-zero exit code.
-            Environment.FailFast($"[Xping] {ex.Message}", ex);
+            // Runs even if FinalizeAsync throws something other than XpingNetworkException, so the
+            // "always releases the underlying host" guarantee above actually holds.
+            await ShutdownAsync().ConfigureAwait(false);
         }
-
-        await ShutdownAsync().ConfigureAwait(false);
     }
 
     /// <summary>

--- a/tests/Xping.Sdk.MSTest.Tests/XpingContextTests.cs
+++ b/tests/Xping.Sdk.MSTest.Tests/XpingContextTests.cs
@@ -129,6 +129,25 @@ public sealed class XpingContextTests : IAsyncLifetime
         Assert.Null(exception);
     }
 
+    [Fact]
+    public async Task FinalizeAndShutdownAsync_AfterInitialize_ResetsContext()
+    {
+        XpingContext.Initialize();
+        Assert.True(XpingContext.IsInitialized);
+
+        await XpingContext.FinalizeAndShutdownAsync().ConfigureAwait(true);
+
+        Assert.False(XpingContext.IsInitialized);
+    }
+
+    [Fact]
+    public async Task FinalizeAndShutdownAsync_BeforeInitialize_DoesNotThrow()
+    {
+        var exception = await Record.ExceptionAsync(async () => await XpingContext.FinalizeAndShutdownAsync().ConfigureAwait(true)).ConfigureAwait(true);
+
+        Assert.Null(exception);
+    }
+
 
     private static TestExecution CreateTestExecution()
     {


### PR DESCRIPTION
MSTest skips [AssemblyCleanup] under method-level parallelization, so XpingContext.FinalizeAsync() was never called and buffered executions were silently discarded. Register an AppDomain.ProcessExit handler that finalizes any initialized-but-unfinalized session as a fallback, mirroring the xUnit adapter's ITestAssemblyFinished safeguard. Extract the finalize+shutdown+strict-mode-FailFast sequence into XpingContext.FinalizeAndShutdownAsync() so both AssemblyCleanup and the safety net share one code path.

See #126 for a known follow-up: the safety net reliably fires and logs a warning, but the finalize/upload work can still lose a race against vstest's testhost teardown under dotnet test.

Fixes #124