### PR TITLE
Fix xUnit retry attempt number recording

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -46,6 +46,28 @@ public void MyTest()
 
 The xUnit adapter uses a message sink pattern that intercepts all test lifecycle events, including skipped tests.
 
+#### Retry Attempts Are Only Tracked For Retry Libraries That Expose A Single-Attempt Hook
+
+**Affected Versions**: All versions
+**Impact**: With some retry libraries, a test that fails and then passes on retry is recorded as a single passing execution — `AttemptNumber` stays `1`, `PassedOnRetry` stays `false`, the hidden failure is not persisted, and the recorded duration is the library's cumulative time across all attempts
+
+**Reason**: xUnit has no native retry support. Retry libraries implement it by running each attempt against a message bus of their own that *discards* the messages of any attempt they intend to retry, then flushing a single synthesised result. A message sink — which is where Xping observes test execution — sits outside that bus, so the discarded attempts never reach it.
+
+**Where retries are fully tracked**: [xRetry](https://github.com/JoshKeegan/xRetry) exposes `RetryTestCaseRunner.RunAsync` publicly so other xUnit extensions can supply the delegate that runs one attempt. Xping uses it, which places it *inside* the retry loop: every attempt is recorded as its own `TestExecution` with the correct `AttemptNumber`, its own duration, and — for the attempts the retry hid — the failure message, stack trace and exception type. The retry library keeps full control of the retry count, delays, skip-on-exception handling and what the runner is told, so test behavior is unchanged.
+
+**Where they are not**: libraries that inline the retry loop inside their test case's `RunAsync` behind a private delayed or blocking bus — including the retry sample in xUnit's own documentation — expose no such hook. Xping leaves those test cases untouched and records only the attempt the library reports.
+
+```csharp
+// Fully tracked: two executions recorded — attempt 1 Failed, attempt 2 Passed
+[RetryFact(3)]
+public void FlakyTest()
+{
+    // ...
+}
+```
+
+**Note**: `AttemptNumber` is also read from a `RetryAttempt` trait or an attempt number in the display name (`(attempt 2)`, `[Retry 2]`) when a library publishes one of those.
+
 ---
 
 ## General Limitations
@@ -107,3 +129,4 @@ When reporting, please include:
 |---------|---------|
 | 1.0.0   | Initial documentation - NUnit and MSTest `[Ignore]` limitation |
 | 1.1.0   | Added known CI flaky test `RecordTest_AfterInitialize_DoesNotThrow` as intentional flakiness example |
+| 1.2.0   | Documented xUnit retry attempt tracking and the retry libraries it covers |

--- a/src/Xping.Sdk.Core/Services/Retry/RetryAttributeRegistry.cs
+++ b/src/Xping.Sdk.Core/Services/Retry/RetryAttributeRegistry.cs
@@ -74,7 +74,8 @@ public static class RetryAttributeRegistry
     /// <returns>True if the attribute is recognized as a retry attribute; otherwise, false.</returns>
     /// <remarks>
     /// This method checks all framework registries to determine if the attribute name
-    /// matches any known retry attribute pattern. Case-insensitive comparison is used.
+    /// matches any known retry attribute pattern. Case-insensitive comparison is used,
+    /// and the <c>Attribute</c> suffix is optional on either side of the comparison.
     /// </remarks>
     public static bool IsKnownRetryAttribute(string attributeName)
     {
@@ -83,9 +84,9 @@ public static class RetryAttributeRegistry
             return false;
         }
 
-        return XUnitRetryAttributes.Contains(attributeName) ||
-               NUnitRetryAttributes.Contains(attributeName) ||
-               MSTestRetryAttributes.Contains(attributeName);
+        return Matches(XUnitRetryAttributes, attributeName) ||
+               Matches(NUnitRetryAttributes, attributeName) ||
+               Matches(MSTestRetryAttributes, attributeName);
     }
 
     /// <summary>
@@ -150,6 +151,10 @@ public static class RetryAttributeRegistry
     /// <param name="framework">The target framework: "xunit", "nunit", or "mstest" (case-insensitive).</param>
     /// <param name="attributeName">The attribute name to check.</param>
     /// <returns>True if the attribute is registered for the specified framework; otherwise, false.</returns>
+    /// <remarks>
+    /// The <c>Attribute</c> suffix is optional on either side of the comparison: an attribute used as
+    /// <c>[Retry]</c> matches a registered <c>"RetryAttribute"</c> and vice versa.
+    /// </remarks>
     public static bool IsRegisteredForFramework(string framework, string attributeName)
     {
         if (string.IsNullOrWhiteSpace(attributeName))
@@ -158,6 +163,32 @@ public static class RetryAttributeRegistry
         }
 
         var registry = GetAttributesForFramework(framework);
-        return registry.Contains(attributeName);
+        return Matches(registry, attributeName);
+    }
+
+    /// <summary>
+    /// Checks a registry for the given attribute name, treating the <c>Attribute</c> suffix as optional.
+    /// </summary>
+    /// <remarks>
+    /// Callers reach this method with either spelling: detectors historically strip the suffix from the
+    /// runtime type name before the lookup, while the registries are seeded with the CLR type names that
+    /// carry it. Comparing both forms keeps entries such as <c>"RetryAttribute"</c> reachable regardless
+    /// of which spelling the caller and the registry happen to use.
+    /// </remarks>
+    private static bool Matches(HashSet<string> registry, string attributeName)
+    {
+        if (registry.Contains(attributeName))
+        {
+            return true;
+        }
+
+        const string suffix = "Attribute";
+
+        if (attributeName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return registry.Contains(attributeName.Substring(0, attributeName.Length - suffix.Length));
+        }
+
+        return registry.Contains(attributeName + suffix);
     }
 }

--- a/src/Xping.Sdk.XUnit/Retry/IXUnitRetryDetector.cs
+++ b/src/Xping.Sdk.XUnit/Retry/IXUnitRetryDetector.cs
@@ -1,0 +1,31 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.Core.Services.Retry;
+using Xunit.Abstractions;
+
+namespace Xping.Sdk.XUnit.Retry;
+
+/// <summary>
+/// xUnit-specific extension of <see cref="IRetryDetector{T}"/> that accepts an attempt number known
+/// by the caller instead of inferring one from the test case.
+/// </summary>
+/// <remarks>
+/// <see cref="XpingRetryTestCase"/> drives the retry library's loop and therefore knows exactly which
+/// attempt produced a result. The base interface has no way to carry that, and ambient state would race
+/// with xUnit's asynchronous message bus, so the attempt travels as an explicit argument instead.
+/// </remarks>
+internal interface IXUnitRetryDetector : IRetryDetector<ITest>
+{
+    /// <summary>
+    /// Detects retry metadata for a test, using the supplied attempt number verbatim.
+    /// </summary>
+    /// <param name="test">The test being recorded.</param>
+    /// <param name="testOutcome">The outcome of this attempt.</param>
+    /// <param name="attemptNumber">The 1-based attempt number this result belongs to.</param>
+    /// <returns>The retry metadata, or null when the test carries no known retry attribute.</returns>
+    RetryMetadata? DetectRetryMetadata(ITest test, TestOutcome testOutcome, int attemptNumber);
+}

--- a/src/Xping.Sdk.XUnit/Retry/IXpingManagedTestCase.cs
+++ b/src/Xping.Sdk.XUnit/Retry/IXpingManagedTestCase.cs
@@ -1,0 +1,20 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+namespace Xping.Sdk.XUnit.Retry;
+
+/// <summary>
+/// Marks a test case whose executions are recorded by Xping from inside the retry loop.
+/// </summary>
+/// <remarks>
+/// Messages carrying a test case with this marker have already been recorded per attempt by
+/// <see cref="XpingAttemptMessageBus"/>, so <see cref="XpingMessageSink"/> forwards them to the runner
+/// without recording them a second time. Without this, the retry library's flushed final message —
+/// which carries the cumulative duration of every attempt — would be recorded on top of the attempt
+/// Xping already captured with its true duration.
+/// </remarks>
+internal interface IXpingManagedTestCase
+{
+}

--- a/src/Xping.Sdk.XUnit/Retry/RetryTestCaseHook.cs
+++ b/src/Xping.Sdk.XUnit/Retry/RetryTestCaseHook.cs
@@ -1,0 +1,107 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xping.Sdk.XUnit.Retry;
+
+/// <summary>
+/// Binds — by reflection, without taking a dependency on the retry library — to a retry runner that
+/// lets a caller supply the single-attempt delegate, and therefore observe every attempt.
+/// </summary>
+/// <remarks>
+/// <para>
+/// xUnit retry libraries run their attempts behind a message bus of their own that discards the
+/// messages of any attempt they intend to retry. A message sink such as <see cref="XpingMessageSink"/>
+/// sits outside that bus and can only ever see the one attempt the library chooses to flush.
+/// </para>
+/// <para>
+/// xRetry exposes <c>public static Task&lt;RunSummary&gt; RetryTestCaseRunner.RunAsync(IRetryableTestCase,
+/// IMessageSink, IMessageBus, CancellationTokenSource, Func&lt;IMessageBus, Task&lt;RunSummary&gt;&gt;)</c>
+/// explicitly so other xUnit extensions can integrate with it. Supplying the final parameter puts Xping
+/// between the library's blocking bus and the actual test runner, which is the only place every attempt
+/// is visible. The library keeps full control of the retry count, delays, skip-on-exception handling and
+/// flushing, so test behavior is unchanged.
+/// </para>
+/// <para>
+/// The signature is validated before use and every failure path returns <see langword="null"/>, which
+/// leaves the test case unwrapped and behaving exactly as it does without Xping.
+/// </para>
+/// </remarks>
+internal static class RetryTestCaseHook
+{
+    private const string RunnerTypeName = "xRetry.RetryTestCaseRunner";
+    private const string RunAsyncMethodName = "RunAsync";
+
+    // Keyed by the assembly that declares the test case, so the reflection cost is paid once per
+    // retry library rather than once per test case.
+    private static readonly ConcurrentDictionary<Assembly, MethodInfo?> _hooks = new();
+
+    /// <summary>
+    /// Resolves the retry runner hook for the library that declares the given test case.
+    /// </summary>
+    /// <param name="testCase">The test case discovered by the retry library.</param>
+    /// <returns>The runner method, or null when the library exposes no compatible hook.</returns>
+    internal static MethodInfo? Resolve(IXunitTestCase testCase) =>
+        _hooks.GetOrAdd(testCase.GetType().Assembly, ResolveCore);
+
+    /// <summary>
+    /// Determines whether the given test case is one the resolved hook can run.
+    /// </summary>
+    /// <remarks>
+    /// The hook's first parameter is the library's own retryable-test-case contract
+    /// (<c>xRetry.IRetryableTestCase</c>), so an assignability check is both the precise test for
+    /// "this case carries retry configuration" and the guarantee that the invocation will bind.
+    /// </remarks>
+    internal static bool CanRun(MethodInfo hook, IXunitTestCase testCase) =>
+        hook.GetParameters()[0].ParameterType.IsInstanceOfType(testCase);
+
+    private static MethodInfo? ResolveCore(Assembly assembly)
+    {
+        try
+        {
+            Type? runnerType = assembly.GetType(RunnerTypeName, throwOnError: false);
+            if (runnerType == null)
+            {
+                return null;
+            }
+
+            foreach (MethodInfo method in runnerType.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (method.Name == RunAsyncMethodName && HasExpectedSignature(method))
+                {
+                    return method;
+                }
+            }
+
+            return null;
+        }
+        catch
+        {
+            // A library that cannot be inspected is simply not hooked.
+            return null;
+        }
+    }
+
+    private static bool HasExpectedSignature(MethodInfo method)
+    {
+        if (method.ReturnType != typeof(Task<RunSummary>))
+        {
+            return false;
+        }
+
+        ParameterInfo[] parameters = method.GetParameters();
+
+        return parameters.Length == 5 &&
+               typeof(IXunitTestCase).IsAssignableFrom(parameters[0].ParameterType) &&
+               parameters[1].ParameterType == typeof(IMessageSink) &&
+               parameters[2].ParameterType == typeof(IMessageBus) &&
+               parameters[3].ParameterType == typeof(CancellationTokenSource) &&
+               parameters[4].ParameterType == typeof(Func<IMessageBus, Task<RunSummary>>);
+    }
+}

--- a/src/Xping.Sdk.XUnit/Retry/XUnitRetryDetector.cs
+++ b/src/Xping.Sdk.XUnit/Retry/XUnitRetryDetector.cs
@@ -22,12 +22,19 @@ namespace Xping.Sdk.XUnit.Retry;
 /// This detector uses reflection to identify and extract metadata from these retry attributes.
 /// </remarks>
 [SuppressMessage("Performance", "CA1812", Justification = "Instantiated by the DI container.")]
-internal sealed class XUnitRetryDetector : IRetryDetector<ITest>
+internal sealed class XUnitRetryDetector : IXUnitRetryDetector
 {
     private static readonly string[] _attemptSeparators = ["(attempt", ")"];
 
     /// <inheritdoc/>
-    RetryMetadata? IRetryDetector<ITest>.DetectRetryMetadata(ITest test, TestOutcome testOutcome)
+    RetryMetadata? IRetryDetector<ITest>.DetectRetryMetadata(ITest test, TestOutcome testOutcome) =>
+        Detect(test, testOutcome, attemptNumber: null);
+
+    /// <inheritdoc/>
+    RetryMetadata? IXUnitRetryDetector.DetectRetryMetadata(ITest test, TestOutcome testOutcome, int attemptNumber) =>
+        Detect(test, testOutcome, attemptNumber);
+
+    private static RetryMetadata? Detect(ITest test, TestOutcome testOutcome, int? attemptNumber)
     {
         if (test.TestCase?.TestMethod?.Method == null)
         {
@@ -50,7 +57,7 @@ internal sealed class XUnitRetryDetector : IRetryDetector<ITest>
             return null;
         }
 
-        return ExtractRetryMetadata(retryAttribute, test, testOutcome);
+        return ExtractRetryMetadata(retryAttribute, test, testOutcome, attemptNumber);
     }
 
     private static MethodInfo? GetMethodInfo(IMethodInfo method)
@@ -89,10 +96,9 @@ internal sealed class XUnitRetryDetector : IRetryDetector<ITest>
         // Look for known retry attributes
         foreach (object attr in attributes)
         {
-            Type attrType = attr.GetType();
-            string attrName = attrType.Name.Replace("Attribute", "");
-
-            if (RetryAttributeRegistry.IsRegisteredForFramework("xunit", attrName))
+            // The raw type name is passed through: the registry treats the "Attribute" suffix as
+            // optional, so stripping it here would make suffixed entries unreachable.
+            if (RetryAttributeRegistry.IsRegisteredForFramework("xunit", attr.GetType().Name))
             {
                 return attr as Attribute;
             }
@@ -101,55 +107,40 @@ internal sealed class XUnitRetryDetector : IRetryDetector<ITest>
         return null;
     }
 
-    private static RetryMetadata ExtractRetryMetadata(Attribute retryAttribute, ITest test, TestOutcome testOutcome)
+    private static RetryMetadata ExtractRetryMetadata(
+        Attribute retryAttribute,
+        ITest test,
+        TestOutcome testOutcome,
+        int? knownAttemptNumber)
     {
         RetryMetadataBuilder builder = new();
         Type attrType = retryAttribute.GetType();
 
-        // Extract MaxRetries property (common in retry attributes)
-        PropertyInfo? maxRetriesProperty =
-            attrType.GetProperty("MaxRetries") ??
-            attrType.GetProperty("Count");
-
-        if (maxRetriesProperty != null)
+        // Extract the configured retry count. The value is recorded exactly as the attribute declares
+        // it: libraries disagree on whether it counts total attempts (xRetry's MaxRetries) or retries
+        // excluding the first, and guessing which one applies would corrupt the record either way.
+        if (TryReadInt(retryAttribute, out int maxRetries, "MaxRetries", "Count"))
         {
-            object? value = maxRetriesProperty.GetValue(retryAttribute);
-            if (value is int maxRetries)
-            {
-                builder.WithMaxRetries(maxRetries);
-            }
+            builder.WithMaxRetries(maxRetries);
         }
 
-        // Extract Delay property if available
-        PropertyInfo? delayProperty =
-            attrType.GetProperty("DelayMilliseconds") ??
-            attrType.GetProperty("Delay");
-
-        if (delayProperty != null)
+        // Extract the configured delay between attempts if available
+        if (TryReadInt(retryAttribute, out int delayMs, "DelayMilliseconds", "DelayBetweenRetriesMs", "Delay"))
         {
-            object? value = delayProperty.GetValue(retryAttribute);
-            if (value is int delayMs)
-            {
-                builder.WithDelayBetweenRetries(TimeSpan.FromMilliseconds(delayMs));
-            }
+            builder.WithDelayBetweenRetries(TimeSpan.FromMilliseconds(delayMs));
         }
 
-        // Extract Reason property if available
-        PropertyInfo? reasonProperty =
-            attrType.GetProperty("Reason") ??
-            attrType.GetProperty("RetryReason");
-
-        if (reasonProperty != null)
+        // Extract Reason if available
+        if (TryReadMember(retryAttribute, out object? reasonValue, "Reason", "RetryReason") &&
+            reasonValue is string reason &&
+            !string.IsNullOrWhiteSpace(reason))
         {
-            object? value = reasonProperty.GetValue(retryAttribute);
-            if (value is string reason && !string.IsNullOrWhiteSpace(reason))
-            {
-                builder.WithRetryReason(reason);
-            }
+            builder.WithRetryReason(reason);
         }
 
-        // Get the current attempt number
-        int attemptNumber = GetCurrentAttemptNumber(test);
+        // Use the attempt number the caller established when it drove the retry loop itself,
+        // and fall back to inference only when nothing observed the attempts.
+        int attemptNumber = knownAttemptNumber ?? GetCurrentAttemptNumber(test);
 
         RetryMetadata metadata = builder
             .WithRetryAttributeName(attrType.Name.Replace("Attribute", ""))
@@ -239,38 +230,81 @@ internal sealed class XUnitRetryDetector : IRetryDetector<ITest>
     private static Dictionary<string, string> ExtractAdditionalMetadata(Attribute retryAttribute)
     {
         Dictionary<string, string> additionalMetadata = [];
-        Type attrType = retryAttribute.GetType();
 
-        // Look for common retry-related properties
-        string[] propertiesToCheck =
+        // Look for common retry-related members
+        string[] membersToCheck =
         [
             "ExceptionTypes",
             "Filter",
             "OnlyRetryOn",
             "Skip",
+            "SkipOnExceptions",
             "Timeout"
         ];
 
-        foreach (string propertyName in propertiesToCheck)
+        foreach (string memberName in membersToCheck)
         {
-            PropertyInfo? property = attrType.GetProperty(propertyName);
-            if (property != null)
+            if (TryReadMember(retryAttribute, out object? value, memberName) && value != null)
             {
-                try
-                {
-                    object? value = property.GetValue(retryAttribute);
-                    if (value != null)
-                    {
-                        additionalMetadata[propertyName] = value.ToString() ?? string.Empty;
-                    }
-                }
-                catch
-                {
-                    // Ignore property access errors
-                }
+                additionalMetadata[memberName] = value.ToString() ?? string.Empty;
             }
         }
 
         return additionalMetadata;
+    }
+
+    /// <summary>
+    /// Reads the first of the named members that exists on the attribute and holds an <see cref="int"/>.
+    /// </summary>
+    private static bool TryReadInt(Attribute retryAttribute, out int value, params string[] memberNames)
+    {
+        if (TryReadMember(retryAttribute, out object? raw, memberNames) && raw is int intValue)
+        {
+            value = intValue;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Reads the first of the named members that exists on the attribute, checking properties and fields.
+    /// </summary>
+    /// <remarks>
+    /// Fields are checked as well as properties because retry attributes commonly declare their
+    /// configuration as public readonly fields — xRetry's <c>RetryFactAttribute.MaxRetries</c> and
+    /// <c>DelayBetweenRetriesMs</c> among them — which a property-only lookup silently misses.
+    /// </remarks>
+    private static bool TryReadMember(Attribute retryAttribute, out object? value, params string[] memberNames)
+    {
+        Type attrType = retryAttribute.GetType();
+
+        foreach (string memberName in memberNames)
+        {
+            try
+            {
+                PropertyInfo? property = attrType.GetProperty(memberName);
+                if (property != null && property.CanRead)
+                {
+                    value = property.GetValue(retryAttribute);
+                    return true;
+                }
+
+                FieldInfo? field = attrType.GetField(memberName);
+                if (field != null)
+                {
+                    value = field.GetValue(retryAttribute);
+                    return true;
+                }
+            }
+            catch
+            {
+                // Ignore member access errors and continue with the next candidate name
+            }
+        }
+
+        value = null;
+        return false;
     }
 }

--- a/src/Xping.Sdk.XUnit/Retry/XpingAttemptMessageBus.cs
+++ b/src/Xping.Sdk.XUnit/Retry/XpingAttemptMessageBus.cs
@@ -1,0 +1,133 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using System.Diagnostics;
+using Xping.Sdk.Core.Models.Executions;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xping.Sdk.XUnit.Retry;
+
+/// <summary>
+/// Message bus for a single retry attempt: it records the attempt's outcome to Xping and forwards every
+/// message, unchanged, to the retry library's bus.
+/// </summary>
+/// <remarks>
+/// One instance is created per attempt, so the attempt number is carried by the bus itself rather than
+/// inferred from ambient state — which would be unreliable, because xUnit's <see cref="MessageBus"/>
+/// dispatches to sinks on its own thread, well after the attempt has moved on.
+/// Forwarding is unconditional: whether the attempt is ultimately reported or discarded stays entirely
+/// the retry library's decision.
+/// </remarks>
+internal sealed class XpingAttemptMessageBus(
+    IMessageBus inner,
+    XpingMessageSink sink,
+    int attemptNumber,
+    IReadOnlyCollection<string> skipOnExceptionFullNames) : IMessageBus
+{
+    private DateTime _startTime = DateTime.UtcNow;
+    private long _startTimestamp = Stopwatch.GetTimestamp();
+
+    /// <inheritdoc/>
+    public bool QueueMessage(IMessageSinkMessage message)
+    {
+        try
+        {
+            Observe(message);
+        }
+        catch
+        {
+            // Recording must never interfere with test execution.
+        }
+
+        return inner.QueueMessage(message);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        // The inner bus is owned by the retry library, which disposes it itself.
+    }
+
+    private void Observe(IMessageSinkMessage message)
+    {
+        switch (message)
+        {
+            case ITestStarting:
+                _startTime = DateTime.UtcNow;
+                _startTimestamp = Stopwatch.GetTimestamp();
+                break;
+
+            case ITestPassed testPassed:
+                Record(
+                    testPassed.Test,
+                    TestOutcome.Passed,
+                    XpingMessageSink.CalculateDuration(testPassed.ExecutionTime),
+                    testPassed.Output,
+                    exceptionType: null,
+                    errorMessage: null,
+                    stackTrace: null);
+                break;
+
+            case ITestFailed testFailed:
+                RecordFailure(testFailed);
+                break;
+
+            case ITestSkipped testSkipped:
+                Record(
+                    testSkipped.Test,
+                    TestOutcome.Skipped,
+                    // xUnit hardcodes ExecutionTime to 0 for skipped tests, so measure it here instead.
+                    XpingMessageSink.CalculateDuration(_startTimestamp, Stopwatch.GetTimestamp()),
+                    output: string.Empty,
+                    exceptionType: null,
+                    errorMessage: $"Test skipped: {testSkipped.Reason}",
+                    stackTrace: null);
+                break;
+        }
+    }
+
+    private void RecordFailure(ITestFailed testFailed)
+    {
+        string? exceptionType = testFailed.ExceptionTypes?.FirstOrDefault();
+
+        // A retry library may present a failure caused by one of its skip-on exception types as a skip
+        // (xRetry does, via the transformer inside its own bus, which runs after this one). Recording
+        // the failure verbatim would contradict the outcome xUnit ultimately reports for the test.
+        TestOutcome outcome = IsSkipOnException(exceptionType) ? TestOutcome.Skipped : TestOutcome.Failed;
+
+        Record(
+            testFailed.Test,
+            outcome,
+            XpingMessageSink.CalculateDuration(testFailed.ExecutionTime),
+            testFailed.Output,
+            exceptionType,
+            errorMessage: string.Join(Environment.NewLine, testFailed.Messages ?? []),
+            stackTrace: string.Join(Environment.NewLine, testFailed.StackTraces ?? []));
+    }
+
+    private bool IsSkipOnException(string? exceptionType) =>
+        exceptionType != null &&
+        skipOnExceptionFullNames.Contains(exceptionType, StringComparer.Ordinal);
+
+    private void Record(
+        ITest test,
+        TestOutcome outcome,
+        TimeSpan duration,
+        string output,
+        string? exceptionType,
+        string? errorMessage,
+        string? stackTrace) =>
+        sink.RecordAttempt(
+            test,
+            outcome,
+            _startTime,
+            duration,
+            output,
+            exceptionType,
+            errorMessage,
+            stackTrace,
+            attemptNumber);
+}

--- a/src/Xping.Sdk.XUnit/Retry/XpingRetryTestCase.cs
+++ b/src/Xping.Sdk.XUnit/Retry/XpingRetryTestCase.cs
@@ -1,0 +1,245 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xping.Sdk.XUnit.Retry;
+
+/// <summary>
+/// Decorates a retry-library test case so that Xping observes every attempt, including the ones the
+/// library discards.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every member is delegated to the wrapped test case, so test identity, traits, collection grouping and
+/// runner correlation are unchanged. Only <see cref="RunAsync"/> differs: it hands the retry library its
+/// own runner loop back (see <see cref="RetryTestCaseHook"/>) while supplying the per-attempt delegate,
+/// which is what lets <see cref="XpingAttemptMessageBus"/> sit inside the loop.
+/// </para>
+/// <para>
+/// The decorator, not the wrapped case, is passed to the per-attempt runner, so every message produced
+/// carries the <see cref="IXpingManagedTestCase"/> marker and <see cref="XpingMessageSink"/> knows those
+/// attempts are already recorded.
+/// </para>
+/// </remarks>
+internal sealed class XpingRetryTestCase : IXunitTestCase, IXpingManagedTestCase
+{
+    private readonly IXunitTestCase _inner;
+    private readonly XpingMessageSink _sink;
+    private readonly MethodInfo _hook;
+    private readonly IReadOnlyCollection<string> _skipOnExceptionFullNames;
+
+    private XpingRetryTestCase(
+        IXunitTestCase inner,
+        XpingMessageSink sink,
+        MethodInfo hook,
+        IReadOnlyCollection<string> skipOnExceptionFullNames)
+    {
+        _inner = inner;
+        _sink = sink;
+        _hook = hook;
+        _skipOnExceptionFullNames = skipOnExceptionFullNames;
+    }
+
+    /// <summary>
+    /// Wraps a test case when its retry library exposes a hook Xping can observe from the inside.
+    /// </summary>
+    /// <param name="testCase">The test case discovered by xUnit.</param>
+    /// <param name="sink">The sink that records the observed attempts.</param>
+    /// <returns>
+    /// The wrapped test case, or null when the case is not retryable or its library exposes no
+    /// compatible hook — in which case the caller must run the original case untouched.
+    /// </returns>
+    internal static XpingRetryTestCase? TryWrap(IXunitTestCase testCase, XpingMessageSink sink)
+    {
+        try
+        {
+            MethodInfo? hook = RetryTestCaseHook.Resolve(testCase);
+            if (hook == null || !RetryTestCaseHook.CanRun(hook, testCase))
+            {
+                return null;
+            }
+
+            return new XpingRetryTestCase(testCase, sink, hook, ReadSkipOnExceptionFullNames(testCase));
+        }
+        catch
+        {
+            // Never let retry observation prevent a test from running.
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<RunSummary> RunAsync(
+        IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus,
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        int attemptNumber = 0;
+
+        Task<RunSummary> RunSingleAttempt(IMessageBus attemptSink)
+        {
+            XpingAttemptMessageBus attemptBus = new(
+                attemptSink,
+                _sink,
+                Interlocked.Increment(ref attemptNumber),
+                _skipOnExceptionFullNames);
+
+            // Mirrors the runners the retry library would have constructed for a single attempt, with
+            // this decorator in place of the wrapped case so its messages are identifiable downstream.
+            return RequiresTheoryRunner(_inner)
+                ? new XunitTheoryTestCaseRunner(
+                        this,
+                        DisplayName,
+                        SkipReason,
+                        constructorArguments,
+                        diagnosticMessageSink,
+                        attemptBus,
+                        aggregator,
+                        cancellationTokenSource)
+                    .RunAsync()
+                : new XunitTestCaseRunner(
+                        this,
+                        DisplayName,
+                        SkipReason,
+                        constructorArguments,
+                        TestMethodArguments,
+                        attemptBus,
+                        aggregator,
+                        cancellationTokenSource)
+                    .RunAsync();
+        }
+
+        try
+        {
+            object? result = _hook.Invoke(
+                null,
+                [
+                    _inner,
+                    diagnosticMessageSink,
+                    messageBus,
+                    cancellationTokenSource,
+                    (Func<IMessageBus, Task<RunSummary>>)RunSingleAttempt
+                ]);
+
+            if (result is Task<RunSummary> runSummary)
+            {
+                return runSummary;
+            }
+        }
+        catch (Exception)
+        {
+            // The hook is an async method, so a failure escaping the invocation itself is an argument
+            // or binding failure raised before any attempt ran. Falling back to the wrapped case is
+            // therefore safe: it cannot re-run a test that already executed.
+        }
+
+        return _inner.RunAsync(
+            diagnosticMessageSink,
+            messageBus,
+            constructorArguments,
+            aggregator,
+            cancellationTokenSource);
+    }
+
+    /// <summary>
+    /// Determines whether an attempt must be run by the theory runner.
+    /// </summary>
+    /// <remarks>
+    /// A test case with arguments is a single pre-enumerated theory row and runs on the standard runner.
+    /// A case without arguments whose method carries data attributes still has its data to enumerate,
+    /// which only the theory runner does.
+    /// </remarks>
+    private static bool RequiresTheoryRunner(IXunitTestCase testCase)
+    {
+        if (testCase.TestMethodArguments != null)
+        {
+            return false;
+        }
+
+        if (testCase is XunitTheoryTestCase)
+        {
+            return true;
+        }
+
+        try
+        {
+            return testCase.TestMethod?.Method?.GetCustomAttributes(typeof(DataAttribute)).Any() == true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads the exception types the retry library reports as skips rather than failures.
+    /// </summary>
+    private static string[] ReadSkipOnExceptionFullNames(IXunitTestCase testCase)
+    {
+        try
+        {
+            PropertyInfo? property = testCase.GetType().GetProperty("SkipOnExceptionFullNames");
+            if (property?.GetValue(testCase) is string[] fullNames)
+            {
+                return fullNames;
+            }
+        }
+        catch
+        {
+            // Treated as "no skip-on exceptions configured".
+        }
+
+        return [];
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Delegated members
+    // --------------------------------------------------------------------------------------------
+
+    /// <inheritdoc/>
+    public string DisplayName => _inner.DisplayName;
+
+    /// <inheritdoc/>
+    public string? SkipReason => _inner.SkipReason;
+
+    /// <inheritdoc/>
+    public ISourceInformation SourceInformation
+    {
+        get => _inner.SourceInformation;
+        set => _inner.SourceInformation = value;
+    }
+
+    /// <inheritdoc/>
+    public ITestMethod TestMethod => _inner.TestMethod;
+
+    /// <inheritdoc/>
+    public object[] TestMethodArguments => _inner.TestMethodArguments;
+
+    /// <inheritdoc/>
+    public Dictionary<string, List<string>> Traits => _inner.Traits;
+
+    /// <inheritdoc/>
+    public string UniqueID => _inner.UniqueID;
+
+    /// <inheritdoc/>
+    public IMethodInfo Method => _inner.Method;
+
+    /// <inheritdoc/>
+    public Exception? InitializationException => _inner.InitializationException;
+
+    /// <inheritdoc/>
+    public int Timeout => _inner.Timeout;
+
+    /// <inheritdoc/>
+    public void Serialize(IXunitSerializationInfo info) => _inner.Serialize(info);
+
+    /// <inheritdoc/>
+    public void Deserialize(IXunitSerializationInfo info) => _inner.Deserialize(info);
+}

--- a/src/Xping.Sdk.XUnit/Xping.Sdk.XUnit.csproj
+++ b/src/Xping.Sdk.XUnit/Xping.Sdk.XUnit.csproj
@@ -18,6 +18,12 @@
   </ItemGroup>
   
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Xping.Sdk.XUnit.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Xping.Sdk.Core\Xping.Sdk.Core.csproj" />
     <ProjectReference Include="..\Xping.Sdk.Shared\Xping.Sdk.Shared.csproj" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Xping.Sdk.XUnit/XpingContext.cs
+++ b/src/Xping.Sdk.XUnit/XpingContext.cs
@@ -47,7 +47,8 @@ public class XpingContext : XpingContextOrchestrator
         IHost host = CreateHostBuilder(configuration)
             .ConfigureServices(services =>
             {
-                // Register the xUnit-specific retry detector
+                // Register the xUnit-specific retry detector. The registered instance also implements
+                // IXUnitRetryDetector, which callers that know the attempt number reach by casting.
                 services.AddSingleton<IRetryDetector<ITest>, XUnitRetryDetector>();
             })
             .Build();

--- a/src/Xping.Sdk.XUnit/XpingMessageSink.cs
+++ b/src/Xping.Sdk.XUnit/XpingMessageSink.cs
@@ -16,6 +16,7 @@ using Xping.Sdk.Core.Services.Identity;
 using Xping.Sdk.Core.Services.Retry;
 using Xping.Sdk.Shared;
 using Xping.Sdk.Core.Attributes;
+using Xping.Sdk.XUnit.Retry;
 
 namespace Xping.Sdk.XUnit;
 
@@ -48,6 +49,15 @@ public sealed class XpingMessageSink(
     /// <returns>True if the message was processed successfully.</returns>
     bool IMessageSink.OnMessage(IMessageSinkMessage message)
     {
+        // Attempts of a test case Xping drives itself are recorded from inside the retry loop, where
+        // every attempt is still visible. What reaches this sink is only what the retry library chose
+        // to report — one attempt, carrying the cumulative duration of all of them — so it is forwarded
+        // to the runner without being recorded a second time.
+        if (message is ITestMessage testMessage && testMessage.Test.TestCase is IXpingManagedTestCase)
+        {
+            return _innerSink.OnMessage(message);
+        }
+
         // Handle test lifecycle messages
         switch (message)
         {
@@ -192,6 +202,45 @@ public sealed class XpingMessageSink(
         }
     }
 
+    /// <summary>
+    /// Records a single attempt of a test case whose retry loop Xping observes from the inside.
+    /// </summary>
+    /// <remarks>
+    /// Called by <see cref="XpingAttemptMessageBus"/> once per attempt, including the attempts the retry
+    /// library discards. The attempt number is supplied by the caller rather than inferred, and the
+    /// in-flight slot is opened here because the corresponding <see cref="ITestStarting"/> message is
+    /// not routed through this sink's own handlers for a managed test case.
+    /// </remarks>
+    internal void RecordAttempt(
+        ITest test,
+        TestOutcome outcome,
+        DateTime startTime,
+        TimeSpan duration,
+        string output,
+        string? exceptionType,
+        string? errorMessage,
+        string? stackTrace,
+        int attemptNumber)
+    {
+        string collectionName =
+            test.TestCase?.TestMethod?.TestClass?.TestCollection?.DisplayName ?? string.Empty;
+
+        _executionTracker.RecordTestStart(collectionName);
+
+        RecordTestExecution(
+            test: test,
+            outcome: outcome,
+            startTime: startTime,
+            endTime: DateTime.UtcNow,
+            duration: duration,
+            output: output,
+            exceptionType: exceptionType,
+            errorMessage: errorMessage,
+            stackTrace: stackTrace,
+            collectionName: collectionName,
+            attemptNumber: attemptNumber);
+    }
+
     private void RecordTestExecution(
         ITest test,
         TestOutcome outcome,
@@ -202,7 +251,8 @@ public sealed class XpingMessageSink(
         string? exceptionType,
         string? errorMessage,
         string? stackTrace,
-        string collectionName)
+        string collectionName,
+        int? attemptNumber = null)
     {
         try
         {
@@ -216,7 +266,8 @@ public sealed class XpingMessageSink(
                 exceptionType,
                 errorMessage,
                 stackTrace,
-                collectionName);
+                collectionName,
+                attemptNumber);
 
             XpingContext.RecordTest(execution);
         }
@@ -242,7 +293,8 @@ public sealed class XpingMessageSink(
         string? exceptionType,
         string? errorMessage,
         string? stackTrace,
-        string collectionName)
+        string collectionName,
+        int? attemptNumber)
     {
         ITestCase? testCase = test.TestCase;
         ITestMethod? testMethod = testCase.TestMethod;
@@ -270,7 +322,11 @@ public sealed class XpingMessageSink(
         // Extract test metadata
         TestMetadata metadata = ExtractMetadata(test, output);
         // Detect retry metadata first, so the attempt number is available when claiming a position.
-        RetryMetadata? retryMetadata = _retryDetector.DetectRetryMetadata(test, outcome);
+        // A caller that drove the retry loop knows which attempt this is; without one, the detector
+        // falls back to whatever the retry library left behind on the test case.
+        RetryMetadata? retryMetadata = attemptNumber is int attempt && _retryDetector is IXUnitRetryDetector detector
+            ? detector.DetectRetryMetadata(test, outcome, attempt)
+            : _retryDetector.DetectRetryMetadata(test, outcome);
         (string? configuredStackTrace, bool stackTraceOmitted) = ResolveStackTrace(outcome, stackTrace, captureStackTraces);
         // xUnit has no separate worker concept, so the collection name doubles as both
         // the concurrency worker key and the record's collection metadata.
@@ -278,7 +334,7 @@ public sealed class XpingMessageSink(
         TestOrchestrationRecord orchestrationRecord = _executionTracker.CreateExecutionContext(
             workerId: collectionName,
             collectionName: collectionName,
-            attemptNumber: retryMetadata?.AttemptNumber ?? 1);
+            attemptNumber: retryMetadata?.AttemptNumber ?? attemptNumber ?? 1);
 
         TestExecution testExecution = new TestExecutionBuilder()
             .WithExecutionId(Guid.NewGuid())
@@ -406,13 +462,13 @@ public sealed class XpingMessageSink(
         return metadata;
     }
 
-    private static TimeSpan CalculateDuration(long startTimestamp, long endTimestamp)
+    internal static TimeSpan CalculateDuration(long startTimestamp, long endTimestamp)
     {
         long elapsedTicks = endTimestamp - startTimestamp;
         return TimeSpan.FromTicks(elapsedTicks * TimeSpan.TicksPerSecond / Stopwatch.Frequency);
     }
 
-    private static TimeSpan CalculateDuration(decimal executionTime)
+    internal static TimeSpan CalculateDuration(decimal executionTime)
     {
         // xUnit ExecutionTime is in seconds (decimal); convert to TimeSpan via ticks for precision
         long ticks = (long)(executionTime * TimeSpan.TicksPerSecond);

--- a/src/Xping.Sdk.XUnit/XpingMessageSink.cs
+++ b/src/Xping.Sdk.XUnit/XpingMessageSink.cs
@@ -231,7 +231,7 @@ public sealed class XpingMessageSink(
             test: test,
             outcome: outcome,
             startTime: startTime,
-            endTime: DateTime.UtcNow,
+            endTime: startTime + duration,
             duration: duration,
             output: output,
             exceptionType: exceptionType,

--- a/src/Xping.Sdk.XUnit/XpingTestFrameworkExecutor.cs
+++ b/src/Xping.Sdk.XUnit/XpingTestFrameworkExecutor.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Xping.Sdk.Core.Services.Collector;
 using Xping.Sdk.Core.Services.Identity;
 using Xping.Sdk.Core.Services.Retry;
+using Xping.Sdk.XUnit.Retry;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -56,7 +57,15 @@ public sealed class XpingTestFrameworkExecutor(
             captureStackTraces,
             _assemblyName);
 
+        // Retry libraries discard the messages of the attempts they retry, so those attempts are
+        // invisible to any message sink. Wrapping such a test case lets Xping observe its retry loop
+        // from the inside; every other test case is passed through untouched.
+        // Materialized so that a re-enumeration downstream cannot hand out a second set of wrappers,
+        // each with its own attempt counter, for the same test cases.
+        List<IXunitTestCase> trackedTestCases = [.. testCases
+            .Select(testCase => (IXunitTestCase?)XpingRetryTestCase.TryWrap(testCase, trackingSink) ?? testCase)];
+
         // Run tests with tracking enabled
-        base.RunTestCases(testCases, trackingSink, executionOptions);
+        base.RunTestCases(trackedTestCases, trackingSink, executionOptions);
     }
 }

--- a/tests/Xping.Sdk.Core.Tests/Retry/RetryAttributeRegistryTests.cs
+++ b/tests/Xping.Sdk.Core.Tests/Retry/RetryAttributeRegistryTests.cs
@@ -371,4 +371,52 @@ public sealed class RetryAttributeRegistryTests
         Assert.DoesNotContain(nunitOnly, RetryAttributeRegistry.XUnitRetryAttributes);
         Assert.DoesNotContain(nunitOnly, RetryAttributeRegistry.MSTestRetryAttributes);
     }
+
+    // ---------------------------------------------------------------------------
+    // Attribute suffix — issues #115 and #116
+    // ---------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("xunit")]
+    [InlineData("nunit")]
+    [InlineData("mstest")]
+    public void IsRegisteredForFramework_SuffixStrippedName_MatchesSuffixedRegistryEntry(string framework)
+    {
+        // Regression test: every detector strips the "Attribute" suffix from the runtime type name
+        // before the lookup, which made registry entries such as "RetryAttribute" unreachable and left
+        // any attribute used as [Retry] undetected.
+        Assert.True(RetryAttributeRegistry.IsRegisteredForFramework(framework, "Retry"));
+        Assert.True(RetryAttributeRegistry.IsRegisteredForFramework(framework, "RetryAttribute"));
+    }
+
+    [Fact]
+    public void IsRegisteredForFramework_SuffixedName_MatchesBareRegistryEntry()
+    {
+        // The bare "Retry" entry in the NUnit registry must also be reachable by the CLR type name.
+        Assert.True(RetryAttributeRegistry.IsRegisteredForFramework("nunit", "RetryAttribute"));
+
+        // And a custom attribute registered without the suffix is matched by its type name.
+        var customName = "SuffixProbeRetry_" + Guid.NewGuid().ToString("N");
+        RetryAttributeRegistry.RegisterCustomRetryAttribute("xunit", customName);
+
+        Assert.True(RetryAttributeRegistry.IsRegisteredForFramework("xunit", customName + "Attribute"));
+        Assert.True(RetryAttributeRegistry.IsKnownRetryAttribute(customName + "Attribute"));
+    }
+
+    [Fact]
+    public void IsRegisteredForFramework_XRetryAttributeNames_AreRecognized()
+    {
+        // The attribute names xRetry actually declares, as the detector sees them.
+        Assert.True(RetryAttributeRegistry.IsRegisteredForFramework("xunit", "RetryFactAttribute"));
+        Assert.True(RetryAttributeRegistry.IsRegisteredForFramework("xunit", "RetryTheoryAttribute"));
+    }
+
+    [Fact]
+    public void IsRegisteredForFramework_UnrelatedName_IsNotMatched()
+    {
+        // Suffix tolerance must not turn unrelated attributes into retry attributes.
+        Assert.False(RetryAttributeRegistry.IsRegisteredForFramework("xunit", "Fact"));
+        Assert.False(RetryAttributeRegistry.IsRegisteredForFramework("xunit", "FactAttribute"));
+        Assert.False(RetryAttributeRegistry.IsRegisteredForFramework("xunit", "Attribute"));
+    }
 }

--- a/tests/Xping.Sdk.XUnit.Tests/Retry/XUnitRetryDetectorTests.cs
+++ b/tests/Xping.Sdk.XUnit.Tests/Retry/XUnitRetryDetectorTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using Moq;
 using Xping.Sdk.Core.Models.Executions;
 using Xping.Sdk.Core.Services.Retry;
+using Xping.Sdk.XUnit.Retry;
 using Xunit.Abstractions;
 
 namespace Xping.Sdk.XUnit.Tests.Retry;
@@ -241,6 +242,83 @@ public sealed class XUnitRetryDetectorTests : IAsyncLifetime
     }
 
     // ---------------------------------------------------------------------------
+    // Attempt number — supplied by the caller
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void DetectRetryMetadata_WithExplicitAttempt_UsesSuppliedAttemptNumber()
+    {
+        // Regression test for issue #115: xRetry sets neither a trait nor a decorated display name, so
+        // an attempt number is only ever known to the caller that drove the retry loop.
+        var mockTest = CreateMockTest(
+            typeof(TestClass).FullName!,
+            nameof(TestClass.TestMethodWithRetry));
+
+        var result = ((IXUnitRetryDetector)_detector).DetectRetryMetadata(mockTest, TestOutcome.Passed, 2);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.AttemptNumber);
+        Assert.True(result.PassedOnRetry);
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_WithExplicitAttempt_OverridesInferredAttemptNumber()
+    {
+        var traits = new Dictionary<string, List<string>>
+        {
+            ["RetryAttempt"] = ["7"]
+        };
+        var mockTest = CreateMockTest(
+            typeof(TestClass).FullName!,
+            nameof(TestClass.TestMethodWithRetry),
+            traits: traits);
+
+        var result = ((IXUnitRetryDetector)_detector).DetectRetryMetadata(mockTest, TestOutcome.Failed, 3);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.AttemptNumber);
+        Assert.False(result.PassedOnRetry);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Attribute member extraction
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void DetectRetryMetadata_AttributeWithoutSuffixInRegistry_IsStillDetected()
+    {
+        // Regression test for issue #115: the detector stripped the "Attribute" suffix before the
+        // registry lookup, which made suffixed entries such as "RetryAttribute" unreachable.
+        Assert.True(RetryAttributeRegistry.IsRegisteredForFramework("xunit", "RetryAttribute"));
+
+        var mockTest = CreateMockTest(
+            typeof(TestClass).FullName!,
+            nameof(TestClass.TestMethodWithRetry));
+
+        var result = _detector.DetectRetryMetadata(mockTest, TestOutcome.Passed);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_ConfigurationDeclaredAsFields_IsExtracted()
+    {
+        // Regression test for issue #115: retry attributes commonly declare their configuration as
+        // public readonly fields (xRetry does), which a property-only lookup silently missed.
+        RetryAttributeRegistry.RegisterCustomRetryAttribute("xunit", "FieldRetry");
+
+        var mockTest = CreateMockTest(
+            typeof(TestClass).FullName!,
+            nameof(TestClass.TestMethodWithFieldRetry));
+
+        var result = _detector.DetectRetryMetadata(mockTest, TestOutcome.Passed);
+
+        Assert.NotNull(result);
+        Assert.Equal(4, result.MaxRetries);
+        Assert.Equal(TimeSpan.FromMilliseconds(250), result.DelayBetweenRetries);
+    }
+
+    // ---------------------------------------------------------------------------
     // PassedOnRetry
     // ---------------------------------------------------------------------------
 
@@ -322,6 +400,9 @@ public sealed class XUnitRetryDetectorTests : IAsyncLifetime
 
         [Retry(3, DelayMilliseconds = 200)]
         public static void TestMethodWithDelay() { }
+
+        [FieldRetry]
+        public static void TestMethodWithFieldRetry() { }
     }
 
     /// <summary>Mock retry attribute applied in <see cref="TestClass"/>.</summary>
@@ -330,5 +411,16 @@ public sealed class XUnitRetryDetectorTests : IAsyncLifetime
     {
         public int MaxRetries { get; } = maxRetries;
         public int DelayMilliseconds { get; set; }
+    }
+
+    /// <summary>
+    /// Mock retry attribute declaring its configuration as public fields, the way xRetry's
+    /// <c>RetryFactAttribute</c> does.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    private sealed class FieldRetryAttribute : Attribute
+    {
+        public readonly int MaxRetries = 4;
+        public readonly int DelayBetweenRetriesMs = 250;
     }
 }

--- a/tests/Xping.Sdk.XUnit.Tests/Retry/XpingRetryTestCaseTests.cs
+++ b/tests/Xping.Sdk.XUnit.Tests/Retry/XpingRetryTestCaseTests.cs
@@ -1,0 +1,462 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xping.Sdk.Core.Extensions;
+using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.Core.Services.Collector;
+using Xping.Sdk.Core.Services.Identity;
+using Xping.Sdk.Core.Services.Retry;
+using Xping.Sdk.XUnit.Retry;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using xRetry;
+
+namespace Xping.Sdk.XUnit.Tests.Retry;
+
+/// <summary>
+/// Tests for issue #115: retry libraries discard the messages of every attempt they retry, so the
+/// xUnit adapter never saw a second attempt and recorded <c>AttemptNumber = 1</c> for every execution.
+/// </summary>
+/// <remarks>
+/// These tests drive a real <see cref="RetryTestCase"/> from the xRetry package, so the reflection hook
+/// in <c>RetryTestCaseHook</c> is exercised against the library it targets rather than a stand-in.
+/// </remarks>
+[Collection("XpingContext")]
+public sealed class XpingRetryTestCaseTests : IAsyncLifetime
+{
+    // Keep the shared XpingContext singleton shut down: the sink records every execution it builds
+    // through XpingContext.RecordTest, and a live session would collect these fakes and try to upload
+    // them. Everything asserted here is captured before that call.
+    public Task InitializeAsync() => XpingContext.ShutdownAsync().AsTask();
+
+    public Task DisposeAsync() => XpingContext.ShutdownAsync().AsTask();
+
+    [Fact]
+    public async Task RunAsync_TestFailsThenPasses_RecordsBothAttempts()
+    {
+        // Arrange
+        RetryFixture.Reset(failuresBeforePass: 1);
+        (XpingMessageSink sink, RecordingExecutionTracker tracker, RecordingIdentityGenerator identity) = CreateSink();
+        using RetryTestCase retryCase = CreateRetryTestCase(nameof(RetryFixture.FailsThenPasses), maxRetries: 3);
+
+        XpingRetryTestCase? wrapped = XpingRetryTestCase.TryWrap(retryCase, sink);
+        Assert.NotNull(wrapped);
+
+        // Act
+        (RunSummary summary, RecordingMessageBus bus) = await RunAsync(wrapped!);
+
+        // Assert — both attempts were recorded, in order, with their own outcomes
+        Assert.Equal(2, RetryFixture.Invocations);
+        Assert.Equal([(1, TestOutcome.Failed), (2, TestOutcome.Passed)], tracker.Attempts);
+
+        // The failure the retry hid is preserved rather than lost with the discarded attempt
+        Assert.Contains(identity.ErrorMessages, message => message?.Contains("first attempt fails", StringComparison.Ordinal) == true);
+        Assert.Contains(identity.StackTraces, stackTrace => !string.IsNullOrWhiteSpace(stackTrace));
+
+        // xRetry still owns the outcome: the runner is told the test passed
+        Assert.Equal(0, summary.Failed);
+        Assert.Single(bus.Messages.OfType<ITestPassed>());
+        Assert.Empty(bus.Messages.OfType<ITestFailed>());
+    }
+
+    [Fact]
+    public async Task RunAsync_RetriedTest_ReusesSuitePositionOfFirstAttempt()
+    {
+        // Arrange
+        RetryFixture.Reset(failuresBeforePass: 1);
+        (XpingMessageSink sink, RecordingExecutionTracker tracker, _) = CreateSink();
+        using RetryTestCase retryCase = CreateRetryTestCase(nameof(RetryFixture.FailsThenPasses), maxRetries: 3);
+
+        // Act
+        await RunAsync(XpingRetryTestCase.TryWrap(retryCase, sink)!);
+
+        // Assert — a retried test must not consume two positions in the suite
+        Assert.Equal(2, tracker.Records.Count);
+        Assert.Equal(tracker.Records[0].PositionInSuite, tracker.Records[1].PositionInSuite);
+        Assert.Equal(tracker.Records[0].GlobalPosition, tracker.Records[1].GlobalPosition);
+    }
+
+    [Fact]
+    public async Task RunAsync_TestAlwaysFails_RecordsEveryAttempt()
+    {
+        // Arrange
+        RetryFixture.Reset(failuresBeforePass: int.MaxValue);
+        (XpingMessageSink sink, RecordingExecutionTracker tracker, _) = CreateSink();
+        using RetryTestCase retryCase = CreateRetryTestCase(nameof(RetryFixture.FailsThenPasses), maxRetries: 2);
+
+        // Act
+        (RunSummary summary, RecordingMessageBus bus) = await RunAsync(XpingRetryTestCase.TryWrap(retryCase, sink)!);
+
+        // Assert
+        Assert.Equal([(1, TestOutcome.Failed), (2, TestOutcome.Failed)], tracker.Attempts);
+        Assert.Equal(1, summary.Failed);
+        Assert.Single(bus.Messages.OfType<ITestFailed>());
+    }
+
+    [Fact]
+    public async Task RunAsync_PassingTest_RecordsSingleFirstAttempt()
+    {
+        // Arrange
+        RetryFixture.Reset(failuresBeforePass: 0);
+        (XpingMessageSink sink, RecordingExecutionTracker tracker, _) = CreateSink();
+        using RetryTestCase retryCase = CreateRetryTestCase(nameof(RetryFixture.FailsThenPasses), maxRetries: 3);
+
+        // Act
+        (RunSummary summary, _) = await RunAsync(XpingRetryTestCase.TryWrap(retryCase, sink)!);
+
+        // Assert — a test that never needed a retry looks exactly as it did before
+        Assert.Equal([(1, TestOutcome.Passed)], tracker.Attempts);
+        Assert.Equal(0, summary.Failed);
+    }
+
+    [Fact]
+    public async Task RunAsync_TheoryDiscoveredAtRuntime_RecordsEveryAttempt()
+    {
+        // A theory whose data is enumerated at run time is run by a different xUnit runner, so the
+        // attempt delegate has to pick the matching one or the data is never resolved.
+        RetryFixture.Reset(failuresBeforePass: 1);
+        (XpingMessageSink sink, RecordingExecutionTracker tracker, _) = CreateSink();
+        using RetryTheoryDiscoveryAtRuntimeCase theoryCase = new(
+            Mock.Of<IMessageSink>(),
+            TestMethodDisplay.ClassAndMethod,
+            TestMethodDisplayOptions.None,
+            CreateTestMethod(nameof(RetryFixture.TheoryFailsThenPasses)),
+            maxRetries: 3,
+            delayBetweenRetriesMs: 0,
+            skipOnExceptions: []);
+
+        // Act
+        (RunSummary summary, _) = await RunAsync(XpingRetryTestCase.TryWrap(theoryCase, sink)!);
+
+        // Assert
+        Assert.Equal([(1, TestOutcome.Failed), (2, TestOutcome.Passed)], tracker.Attempts);
+        Assert.Equal(0, summary.Failed);
+    }
+
+    [Fact]
+    public void TryWrap_NonRetryTestCase_ReturnsNull()
+    {
+        // Arrange
+        (XpingMessageSink sink, _, _) = CreateSink();
+        using var testCase = new XunitTestCase(
+            Mock.Of<IMessageSink>(),
+            TestMethodDisplay.ClassAndMethod,
+            TestMethodDisplayOptions.None,
+            CreateTestMethod(nameof(RetryFixture.FailsThenPasses)));
+
+        // Act & Assert — an ordinary test case must be left untouched
+        Assert.Null(XpingRetryTestCase.TryWrap(testCase, sink));
+    }
+
+    [Fact]
+    public void Decorator_DelegatesIdentityMembersToWrappedCase()
+    {
+        // Arrange
+        (XpingMessageSink sink, _, _) = CreateSink();
+        using RetryTestCase retryCase = CreateRetryTestCase(nameof(RetryFixture.FailsThenPasses), maxRetries: 3);
+
+        // Act
+        XpingRetryTestCase wrapped = XpingRetryTestCase.TryWrap(retryCase, sink)!;
+
+        // Assert — identity and correlation must be indistinguishable from the wrapped case
+        Assert.Equal(retryCase.UniqueID, wrapped.UniqueID);
+        Assert.Equal(retryCase.DisplayName, wrapped.DisplayName);
+        Assert.Equal(retryCase.SkipReason, wrapped.SkipReason);
+        Assert.Same(retryCase.TestMethod, wrapped.TestMethod);
+        Assert.Same(retryCase.Method, wrapped.Method);
+        Assert.Equal(retryCase.Timeout, wrapped.Timeout);
+        Assert.Equal(retryCase.Traits, wrapped.Traits);
+    }
+
+    private static async Task<(RunSummary summary, RecordingMessageBus bus)> RunAsync(XpingRetryTestCase testCase)
+    {
+        RecordingMessageBus bus = new();
+        using CancellationTokenSource cancellationTokenSource = new();
+
+        RunSummary summary = await testCase.RunAsync(
+                Mock.Of<IMessageSink>(),
+                bus,
+                constructorArguments: [],
+                new ExceptionAggregator(),
+                cancellationTokenSource)
+            .ConfigureAwait(false);
+
+        return (summary, bus);
+    }
+
+    private static RetryTestCase CreateRetryTestCase(string methodName, int maxRetries) =>
+        new(
+            Mock.Of<IMessageSink>(),
+            TestMethodDisplay.ClassAndMethod,
+            TestMethodDisplayOptions.None,
+            CreateTestMethod(methodName),
+            maxRetries,
+            delayBetweenRetriesMs: 0,
+            skipOnExceptions: []);
+
+    private static TestMethod CreateTestMethod(string methodName)
+    {
+        var testAssembly = new TestAssembly(Reflector.Wrap(typeof(RetryFixture).Assembly));
+        var testCollection = new TestCollection(testAssembly, collectionDefinition: null, "retry-collection");
+        var testClass = new TestClass(testCollection, Reflector.Wrap(typeof(RetryFixture)));
+
+        return new TestMethod(testClass, Reflector.Wrap(typeof(RetryFixture).GetMethod(methodName)!));
+    }
+
+    /// <summary>
+    /// Builds a sink backed by the real <see cref="IExecutionTracker"/> and retry detector, wrapped so
+    /// the attempts it records can be inspected.
+    /// </summary>
+    private static (XpingMessageSink sink, RecordingExecutionTracker tracker, RecordingIdentityGenerator identity)
+        CreateSink()
+    {
+        IExecutionTracker inner = new ServiceCollection()
+            .AddXpingCollectors()
+            .BuildServiceProvider()
+            .GetRequiredService<IExecutionTracker>();
+
+        RecordingExecutionTracker tracker = new(inner);
+        RecordingIdentityGenerator identity = new();
+
+        XpingMessageSink sink = new(
+            Mock.Of<IMessageSink>(),
+            tracker,
+            new XUnitRetryDetector(),
+            identity,
+            NullLogger<XpingMessageSink>.Instance,
+            captureStackTraces: true,
+            assemblyName: "Xping.Sdk.XUnit.Tests");
+
+        return (sink, tracker, identity);
+    }
+
+    /// <summary>
+    /// A test method driven directly by these tests rather than by the runner.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="FactAttribute"/> is required because xUnit's <see cref="XunitTestCase"/> reads its
+    /// display name and skip reason from one; <see cref="RetryFactAttribute"/> is used so the retry
+    /// detector sees the same attribute it would in a real suite. The class is private so that xUnit's
+    /// discoverer — which only scans public types — never picks this deliberately failing method up as
+    /// a test of its own.
+    /// </remarks>
+    [SuppressMessage("Performance", "CA1812", Justification = "Instantiated by the xUnit test runner.")]
+    [SuppressMessage(
+        "Usage",
+        "xUnit1000:Test classes must be public",
+        Justification = "Not a test class: kept private so xUnit never discovers this fixture as a test.")]
+    private sealed class RetryFixture
+    {
+        private static int _failuresBeforePass;
+        private static int _invocations;
+
+        internal static int Invocations => _invocations;
+
+        internal static void Reset(int failuresBeforePass)
+        {
+            _failuresBeforePass = failuresBeforePass;
+            _invocations = 0;
+        }
+
+        [RetryFact]
+        public void FailsThenPasses()
+        {
+            int invocation = Interlocked.Increment(ref _invocations);
+
+            Assert.True(
+                invocation > _failuresBeforePass,
+                $"the first attempt fails on purpose (invocation {invocation})");
+        }
+
+        /// <summary>Theory data that cannot be pre-enumerated, so it is resolved at run time.</summary>
+        public static IEnumerable<object[]> RuntimeData()
+        {
+            yield return [new object()];
+        }
+
+        [RetryTheory]
+        [MemberData(nameof(RuntimeData))]
+        public void TheoryFailsThenPasses(object value)
+        {
+            Assert.NotNull(value);
+            FailsThenPasses();
+        }
+    }
+
+    /// <summary>Captures the messages the retry library reports to the runner.</summary>
+    private sealed class RecordingMessageBus : IMessageBus
+    {
+        private readonly List<IMessageSinkMessage> _messages = [];
+
+        public IReadOnlyList<IMessageSinkMessage> Messages
+        {
+            get
+            {
+                lock (_messages)
+                {
+                    return [.. _messages];
+                }
+            }
+        }
+
+        public bool QueueMessage(IMessageSinkMessage message)
+        {
+            lock (_messages)
+            {
+                _messages.Add(message);
+            }
+
+            return true;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Delegates to a real <see cref="IExecutionTracker"/> while capturing the attempt number and
+    /// outcome of every execution the sink builds.
+    /// </summary>
+    private sealed class RecordingExecutionTracker(IExecutionTracker inner) : IExecutionTracker
+    {
+        private readonly List<TestOrchestrationRecord> _records = [];
+        private readonly List<int> _attemptNumbers = [];
+        private readonly List<TestOutcome> _outcomes = [];
+
+        public IReadOnlyList<TestOrchestrationRecord> Records
+        {
+            get
+            {
+                lock (_records)
+                {
+                    return [.. _records];
+                }
+            }
+        }
+
+        /// <summary>The attempt number and outcome of each recorded execution, in order.</summary>
+        public IReadOnlyList<(int AttemptNumber, TestOutcome Outcome)> Attempts
+        {
+            get
+            {
+                lock (_records)
+                {
+                    return [.. _attemptNumbers.Zip(_outcomes, (attempt, outcome) => (attempt, outcome))];
+                }
+            }
+        }
+
+        public int GlobalPosition => inner.GlobalPosition;
+
+        public int ActiveWorkerCount => inner.ActiveWorkerCount;
+
+        public TestOrchestrationRecord CreateExecutionContext(
+            string? workerId = null,
+            string? collectionName = null,
+            int attemptNumber = 1)
+        {
+            TestOrchestrationRecord record = inner.CreateExecutionContext(workerId, collectionName, attemptNumber);
+
+            lock (_records)
+            {
+                _records.Add(record);
+                _attemptNumbers.Add(attemptNumber);
+            }
+
+            return record;
+        }
+
+        public void RecordTestCompletion(string? workerId, string testFingerprint, string testName, TestOutcome outcome)
+        {
+            lock (_records)
+            {
+                _outcomes.Add(outcome);
+            }
+
+            inner.RecordTestCompletion(workerId, testFingerprint, testName, outcome);
+        }
+
+        public int RecordTestStart(string? workerId = null) => inner.RecordTestStart(workerId);
+
+        public void RecordTestEnd(string? workerId = null) => inner.RecordTestEnd(workerId);
+
+        public int GetWorkerPosition(string? workerId = null) => inner.GetWorkerPosition(workerId);
+
+        public PrecedingTestRecord? GetPreviousTest(string? workerId = null) => inner.GetPreviousTest(workerId);
+
+        public void Clear() => inner.Clear();
+    }
+
+    /// <summary>
+    /// Captures the failure details handed to the identity generator, which is the last point they pass
+    /// through before being written into the execution record.
+    /// </summary>
+    private sealed class RecordingIdentityGenerator : ITestIdentityGenerator
+    {
+        private readonly List<string?> _errorMessages = [];
+        private readonly List<string?> _stackTraces = [];
+
+        public IReadOnlyList<string?> ErrorMessages
+        {
+            get
+            {
+                lock (_errorMessages)
+                {
+                    return [.. _errorMessages];
+                }
+            }
+        }
+
+        public IReadOnlyList<string?> StackTraces
+        {
+            get
+            {
+                lock (_stackTraces)
+                {
+                    return [.. _stackTraces];
+                }
+            }
+        }
+
+        public TestIdentity Generate(
+            string fullyQualifiedName,
+            string assembly,
+            object[]? parameters = null,
+            string? displayName = null,
+            string? testCaseName = null,
+            int? repeatIndex = null,
+            string? testFingerprint = null) => new();
+
+        public string GenerateTestFingerprint(string fullyQualifiedName, string? parameterHash = null) =>
+            fullyQualifiedName;
+
+        public string GenerateParameterHash(object[] parameters) => string.Empty;
+
+        public string? GenerateErrorMessageHash(string? errorMessage)
+        {
+            lock (_errorMessages)
+            {
+                _errorMessages.Add(errorMessage);
+            }
+
+            return errorMessage == null ? null : "error-hash";
+        }
+
+        public string? GenerateStackTraceHash(string? stackTrace)
+        {
+            lock (_stackTraces)
+            {
+                _stackTraces.Add(stackTrace);
+            }
+
+            return stackTrace == null ? null : "stack-hash";
+        }
+    }
+}

--- a/tests/Xping.Sdk.XUnit.Tests/Xping.Sdk.XUnit.Tests.csproj
+++ b/tests/Xping.Sdk.XUnit.Tests/Xping.Sdk.XUnit.Tests.csproj
@@ -13,6 +13,9 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <!-- Test-only: exercises retry observation against a real retry library. The shipped
+         Xping.Sdk.XUnit package takes no dependency on it and binds by reflection instead. -->
+    <PackageReference Include="xRetry" Version="1.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Xping.Sdk.XUnit.Tests/XpingMessageSinkAssemblyNameTests.cs
+++ b/tests/Xping.Sdk.XUnit.Tests/XpingMessageSinkAssemblyNameTests.cs
@@ -122,7 +122,8 @@ public sealed class XpingMessageSinkAssemblyNameTests
                 null,
                 null,
                 null,
-                "worker-1"
+                "worker-1",
+                null // attemptNumber: inferred by the retry detector
             ]);
     }
 }


### PR DESCRIPTION
The xUnit adapter now correctly records retry attempt numbers for test cases using registered retry attributes. Previously, the attempt number was always reported as 1, leading to silent `RetryMasked` findings in `xping report`. This was due to two defects: unreachable registry entries and the inability to source attempt numbers from retry libraries. The registry lookup now accommodates both suffixed and stripped names, ensuring attributes like `[Retry]` are detected. Additionally, the retry test cases are wrapped to allow Xping to observe each attempt, capturing accurate execution details, including failure messages and durations. This change enhances visibility into test retries and addresses related configuration extraction issues. Verified through end-to-end testing with `dotnet test`.

Fixes #115.