### PR TITLE
Fix #116: Record retry attempt numbers for MSTest

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -28,6 +28,28 @@ This document outlines known limitations and edge cases in the Xping SDK. Unders
 
 **Note**: Currently, there is no workaround for tracking ignored tests in MSTest. Only tests that actually execute will be tracked by Xping.
 
+#### Retry Attempts Are Numbered By Counting, Not Reported By The Framework
+
+**Affected Versions**: All versions
+**Impact**: Two runs of the same test identity within one session are recorded as attempt 1 and attempt 2 of a retry, whether or not a retry is what produced them
+
+**What works**: MSTest re-runs the whole per-test lifecycle for every retried attempt — a retry attribute derived from `TestMethodAttribute` invokes the test method again, which builds a fresh test class instance and runs `[TestInitialize]`, the method, and `[TestCleanup]` once more. Xping therefore records **every attempt** as its own `TestExecution`, each with its own outcome, duration and failure text, all sharing one position in the suite. A test that fails and then passes carries `AttemptNumber = 2` and `PassedOnRetry = true` on its final execution, so the masked failure is visible even though the build is green.
+
+```csharp
+// Both attempts recorded: attempt 1 Failed with its error intact, attempt 2 Passed
+[Retry(3)]
+public void FlakyTest()
+{
+    // ...
+}
+```
+
+**Reason for the limitation**: nothing in `TestContext` says which attempt is running, so the adapter derives the number by counting the executions already recorded for the same test fingerprint. A test identity that passed starts a fresh chain, since a retry only ever follows an attempt that did not pass — but two `[DataRow]` rows carrying *identical* values share a fingerprint, and a failing one followed by a repeat of itself is indistinguishable from a retry.
+
+**Where attempts are not tracked**: a retry helper that re-runs only the test method body without going through `ITestMethod.Invoke` bypasses `[TestInitialize]` / `[TestCleanup]` entirely, and Xping sees a single execution for the whole retry loop.
+
+**Note**: `AttemptNumber` is taken from a `RetryAttempt` or `RetryCount` test property, or an attempt marker in the test name (`(Retry 2)`, `[Attempt 2]`), when a retry helper publishes one of those; the counted value is used only as the floor.
+
 ---
 
 ### xUnit
@@ -130,3 +152,4 @@ When reporting, please include:
 | 1.0.0   | Initial documentation - NUnit and MSTest `[Ignore]` limitation |
 | 1.1.0   | Added known CI flaky test `RecordTest_AfterInitialize_DoesNotThrow` as intentional flakiness example |
 | 1.2.0   | Documented xUnit retry attempt tracking and the retry libraries it covers |
+| 1.3.0   | Documented MSTest retry attempt tracking and how attempt numbers are derived |

--- a/samples/SampleApp.MSTest/RetryAttribute.cs
+++ b/samples/SampleApp.MSTest/RetryAttribute.cs
@@ -1,0 +1,55 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+namespace SampleApp.MSTest;
+
+/// <summary>
+/// Re-runs a failing test method up to <see cref="MaxRetries"/> times, reporting only the last
+/// attempt's result to the test platform.
+/// </summary>
+/// <remarks>
+/// <para>
+/// MSTest 3.7 ships no retry attribute, so this is the community pattern every MSTest retry helper
+/// follows: derive from <see cref="TestMethodAttribute"/> and call <c>base.Execute</c> again for
+/// each attempt. It is also the shape MSTest's own <c>[Retry]</c> takes from 3.8 onwards.
+/// </para>
+/// <para>
+/// Each <c>base.Execute</c> call goes through <see cref="ITestMethod.Invoke"/>, which builds a fresh
+/// test class instance and runs the full <c>[TestInitialize]</c> → method → <c>[TestCleanup]</c>
+/// lifecycle. That is what lets Xping observe every attempt: <c>XpingTestBase</c> records one
+/// execution per attempt, numbered in order, so an attempt that failed before a later one passed is
+/// still visible in the session even though the build stays green.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class RetryAttribute : TestMethodAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetryAttribute"/> class.
+    /// </summary>
+    /// <param name="maxRetries">The maximum number of attempts, including the first one.</param>
+    public RetryAttribute(int maxRetries) => MaxRetries = maxRetries;
+
+    /// <summary>
+    /// Gets the maximum number of attempts, including the first one.
+    /// </summary>
+    public int MaxRetries { get; }
+
+    /// <inheritdoc/>
+    public override TestResult[] Execute(ITestMethod testMethod)
+    {
+        TestResult[] results = base.Execute(testMethod);
+
+        for (int attempt = 1; attempt < MaxRetries && HasFailed(results); attempt++)
+        {
+            results = base.Execute(testMethod);
+        }
+
+        return results;
+    }
+
+    private static bool HasFailed(TestResult[] results) =>
+        results.Any(result => result.Outcome == UnitTestOutcome.Failed);
+}

--- a/samples/SampleApp.MSTest/SampleTests.cs
+++ b/samples/SampleApp.MSTest/SampleTests.cs
@@ -16,6 +16,8 @@ namespace SampleApp.MSTest;
 [TestClass]
 public class CalculatorTests : XpingTestBase
 {
+    private static int _passesOnRetryAttempts;
+
     [TestMethod]
     [TestCategory("Unit")]
     public void Add_TwoNumbers_ReturnsSum()
@@ -88,6 +90,27 @@ public class CalculatorTests : XpingTestBase
             $"({simulatedLatencyMs} ms). " +
             "This reproduces flakiness caused by network timeouts, service-side " +
             "back-pressure, or CPU contention that shifts task-scheduling order.");
+    }
+
+    /// <summary>
+    /// FLAKY TEST TYPE 2: A failure masked by a retry.
+    /// Fails on the first attempt and passes on the second, so MSTest reports the test as passed
+    /// and the build stays green. Xping records both attempts — attempt 1 Failed with its error
+    /// intact, attempt 2 Passed with PassedOnRetry — which is what makes the masked failure
+    /// visible in reporting.
+    /// </summary>
+    [Retry(3)]
+    [TestCategory("Flaky")]
+    [TestCategory("Retry")]
+    public void FlakyTest_PassesOnRetry()
+    {
+        // Static, so it survives the fresh test class instance MSTest builds for each attempt.
+        var attempt = Interlocked.Increment(ref _passesOnRetryAttempts);
+
+        Assert.IsTrue(
+            attempt > 1,
+            $"Simulated transient failure on attempt {attempt}. " +
+            "The retry attribute re-runs the test, so the suite still reports green.");
     }
 
     [DataTestMethod]

--- a/src/Xping.Sdk.MSTest/Retry/IMSTestRetryDetector.cs
+++ b/src/Xping.Sdk.MSTest/Retry/IMSTestRetryDetector.cs
@@ -1,0 +1,36 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.Core.Services.Retry;
+
+namespace Xping.Sdk.MSTest.Retry;
+
+/// <summary>
+/// MSTest-specific extension of <see cref="IRetryDetector{T}"/> that identifies the test being
+/// recorded, so the detector can number its attempts.
+/// </summary>
+/// <remarks>
+/// MSTest re-runs the whole per-test lifecycle for every retried attempt — a retry attribute derived
+/// from <c>TestMethodAttribute</c> invokes the test method again, which builds a fresh test class
+/// instance and runs <c>[TestInitialize]</c>, the method, and <c>[TestCleanup]</c> once more. The
+/// adapter therefore already observes each attempt separately; what it cannot see is which attempt an
+/// observation belongs to, because nothing in <see cref="TestContext"/> carries that. Counting the
+/// executions already recorded for the same test identity supplies it, and the identity has to come
+/// from the caller since it is the caller that computes the fingerprint.
+/// </remarks>
+internal interface IMSTestRetryDetector : IRetryDetector<TestContext>
+{
+    /// <summary>
+    /// Detects retry metadata for a test, numbering this execution against the ones already recorded
+    /// for the same test identity in this session.
+    /// </summary>
+    /// <param name="testContext">The context of the test being recorded.</param>
+    /// <param name="testOutcome">The outcome of this attempt.</param>
+    /// <param name="testFingerprint">The fingerprint identifying the test across attempts.</param>
+    /// <returns>The retry metadata, or null when the test carries no known retry attribute.</returns>
+    RetryMetadata? DetectRetryMetadata(TestContext testContext, TestOutcome testOutcome, string testFingerprint);
+}

--- a/src/Xping.Sdk.MSTest/Retry/MSTestRetryDetector.cs
+++ b/src/Xping.Sdk.MSTest/Retry/MSTestRetryDetector.cs
@@ -3,6 +3,7 @@
  * License: [MIT]
  */
 
+using System.Collections.Concurrent;
 using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Xping.Sdk.Core.Models.Builders;
@@ -18,10 +19,27 @@ namespace Xping.Sdk.MSTest.Retry;
 /// MSTest does not have native retry support, but community libraries and custom implementations provide retry functionality.
 /// This detector uses reflection and TestContext to identify and extract retry metadata.
 /// </remarks>
-public sealed class MSTestRetryDetector : IRetryDetector<TestContext>
+public sealed class MSTestRetryDetector : IMSTestRetryDetector
 {
+    /// <summary>
+    /// Attempts recorded so far for each test identity, together with the outcome of the most recent
+    /// one. Only tests carrying a retry attribute are tracked, so the map stays as small as the retry
+    /// surface of the suite. The detector is a DI singleton, which scopes this to the session.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, AttemptRecord> _attempts = new(StringComparer.Ordinal);
+
     /// <inheritdoc/>
-    RetryMetadata? IRetryDetector<TestContext>.DetectRetryMetadata(TestContext testContext, TestOutcome testOutcome)
+    RetryMetadata? IRetryDetector<TestContext>.DetectRetryMetadata(TestContext testContext, TestOutcome testOutcome) =>
+        Detect(testContext, testOutcome, testFingerprint: null);
+
+    /// <inheritdoc/>
+    RetryMetadata? IMSTestRetryDetector.DetectRetryMetadata(
+        TestContext testContext,
+        TestOutcome testOutcome,
+        string testFingerprint) =>
+        Detect(testContext, testOutcome, testFingerprint);
+
+    private RetryMetadata? Detect(TestContext testContext, TestOutcome testOutcome, string? testFingerprint)
     {
         if (testContext == null)
             return null;
@@ -36,7 +54,7 @@ public sealed class MSTestRetryDetector : IRetryDetector<TestContext>
         if (retryAttribute == null)
             return null;
 
-        return ExtractRetryMetadata(retryAttribute, testContext, testOutcome);
+        return ExtractRetryMetadata(retryAttribute, testContext, testOutcome, testFingerprint);
     }
 
     private static MethodInfo? GetTestMethod(TestContext testContext)
@@ -89,50 +107,42 @@ public sealed class MSTestRetryDetector : IRetryDetector<TestContext>
 
         foreach (object attr in attributes)
         {
-            Type attrType = attr.GetType();
-            string attrName = attrType.Name.Replace("Attribute", "");
-
-            if (RetryAttributeRegistry.IsRegisteredForFramework("mstest", attrName))
+            // The runtime type name is passed as-is: the registry treats the "Attribute" suffix as
+            // optional, so stripping it here would make suffixed entries such as "RetryAttribute"
+            // unreachable — which is exactly what kept [Retry] invisible to this detector.
+            if (RetryAttributeRegistry.IsRegisteredForFramework("mstest", attr.GetType().Name))
                 return attr as Attribute;
         }
 
         return null;
     }
 
-    private static RetryMetadata ExtractRetryMetadata(
+    private RetryMetadata ExtractRetryMetadata(
         Attribute retryAttribute,
         TestContext testContext,
-        TestOutcome testOutcome)
+        TestOutcome testOutcome,
+        string? testFingerprint)
     {
         Type attrType = retryAttribute.GetType();
 
-        // Extract MaxRetries property (common names: MaxRetries, Count, RetryCount)
-        PropertyInfo? maxRetriesProperty =
-            attrType.GetProperty("MaxRetries", BindingFlags.Public | BindingFlags.Instance)
-            ?? attrType.GetProperty("Count", BindingFlags.Public | BindingFlags.Instance)
-            ?? attrType.GetProperty("RetryCount", BindingFlags.Public | BindingFlags.Instance);
+        // Extract the configured retry count. The value is recorded exactly as the attribute declares
+        // it: implementations disagree on whether it counts total attempts or retries excluding the
+        // first, and guessing which one applies would corrupt the record either way.
+        TryReadInt(retryAttribute, out int maxRetries, "MaxRetries", "Count", "RetryCount");
 
-        int maxRetries = maxRetriesProperty?.GetValue(retryAttribute) is int mr ? mr : 0;
-
-        // Extract Delay property if available
-        PropertyInfo? delayProperty =
-            attrType.GetProperty("DelayMilliseconds", BindingFlags.Public | BindingFlags.Instance)
-            ?? attrType.GetProperty("Delay", BindingFlags.Public | BindingFlags.Instance);
-
-        TimeSpan delay = delayProperty?.GetValue(retryAttribute) is int delayMs
+        // Extract the configured delay between attempts if available
+        TimeSpan delay = TryReadInt(retryAttribute, out int delayMs, "DelayMilliseconds", "DelayBetweenRetriesMs", "Delay")
             ? TimeSpan.FromMilliseconds(delayMs)
             : TimeSpan.Zero;
 
-        // Extract Reason property if available
-        PropertyInfo? reasonProperty =
-            attrType.GetProperty("Reason", BindingFlags.Public | BindingFlags.Instance)
-            ?? attrType.GetProperty("RetryReason", BindingFlags.Public | BindingFlags.Instance);
-
-        string? reason = reasonProperty?.GetValue(retryAttribute) is string r && !string.IsNullOrWhiteSpace(r)
+        // Extract Reason if available
+        string? reason = TryReadMember(retryAttribute, out object? reasonValue, "Reason", "RetryReason") &&
+                         reasonValue is string r &&
+                         !string.IsNullOrWhiteSpace(r)
             ? r
             : null;
 
-        int attemptNumber = GetAttemptNumber(testContext);
+        int attemptNumber = GetAttemptNumber(testContext, testOutcome, testFingerprint);
 
         RetryMetadata metadata = new RetryMetadataBuilder()
             .WithRetryAttributeName(attrType.Name.Replace("Attribute", ""))
@@ -147,7 +157,50 @@ public sealed class MSTestRetryDetector : IRetryDetector<TestContext>
         return metadata;
     }
 
-    private static int GetAttemptNumber(TestContext testContext)
+    private int GetAttemptNumber(TestContext testContext, TestOutcome testOutcome, string? testFingerprint)
+    {
+        int publishedAttempt = GetPublishedAttemptNumber(testContext);
+
+        if (testFingerprint == null)
+        {
+            // No identity to count against — all that is left is whatever the retry helper published.
+            return publishedAttempt;
+        }
+
+        int countedAttempt = CountAttempt(testFingerprint, testOutcome);
+
+        // A retry helper that publishes the attempt number knows better than the count does, so let it
+        // win — but never report fewer attempts than have actually been recorded for this test.
+        return Math.Max(countedAttempt, publishedAttempt);
+    }
+
+    /// <summary>
+    /// Counts this execution against the ones already recorded for the same test identity and returns
+    /// its 1-based attempt number.
+    /// </summary>
+    /// <remarks>
+    /// A retry only ever follows an attempt that did not pass, so a test identity that passed starts a
+    /// fresh chain. That keeps two runs of a genuinely repeated identity — such as a pair of
+    /// <c>[DataRow]</c> rows carrying identical values, which share a fingerprint — from being reported
+    /// as a retry of one another.
+    /// </remarks>
+    private int CountAttempt(string testFingerprint, TestOutcome testOutcome)
+    {
+        AttemptRecord record = _attempts.AddOrUpdate(
+            testFingerprint,
+            _ => new AttemptRecord(1, testOutcome),
+            (_, previous) => previous.Outcome == TestOutcome.Passed
+                ? new AttemptRecord(1, testOutcome)
+                : new AttemptRecord(previous.AttemptNumber + 1, testOutcome));
+
+        return record.AttemptNumber;
+    }
+
+    /// <summary>
+    /// Reads an attempt number published by a retry helper, either as a test property or as a marker
+    /// in the test name. Returns 1 when nothing published one.
+    /// </summary>
+    private static int GetPublishedAttemptNumber(TestContext testContext)
     {
         // Check for a retry attempt in test properties (some retry libraries set this)
         if (testContext.Properties.Contains("RetryAttempt"))
@@ -206,28 +259,79 @@ public sealed class MSTestRetryDetector : IRetryDetector<TestContext>
     private static Dictionary<string, string> ExtractAdditionalMetadata(Attribute retryAttribute)
     {
         Dictionary<string, string> additionalMetadata = [];
-        Type attrType = retryAttribute.GetType();
 
-        string[] propertiesToCheck = ["ExceptionTypes", "Filter", "OnlyRetryOn", "Skip", "Timeout"];
+        string[] membersToCheck = ["ExceptionTypes", "Filter", "OnlyRetryOn", "Skip", "Timeout"];
 
-        foreach (string propertyName in propertiesToCheck)
+        foreach (string memberName in membersToCheck)
         {
-            PropertyInfo? property = attrType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
-            if (property != null)
-            {
-                try
-                {
-                    object? value = property.GetValue(retryAttribute);
-                    if (value != null)
-                        additionalMetadata[propertyName] = value.ToString() ?? string.Empty;
-                }
-                catch
-                {
-                    // Ignore property access errors
-                }
-            }
+            if (TryReadMember(retryAttribute, out object? value, memberName) && value != null)
+                additionalMetadata[memberName] = value.ToString() ?? string.Empty;
         }
 
         return additionalMetadata;
+    }
+
+    /// <summary>
+    /// Reads the first of the named members that exists on the attribute and holds an <see cref="int"/>.
+    /// </summary>
+    private static bool TryReadInt(Attribute retryAttribute, out int value, params string[] memberNames)
+    {
+        if (TryReadMember(retryAttribute, out object? raw, memberNames) && raw is int intValue)
+        {
+            value = intValue;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Reads the first of the named members that exists on the attribute, checking properties and fields.
+    /// </summary>
+    /// <remarks>
+    /// Fields are checked as well as properties because retry attributes commonly declare their
+    /// configuration as public readonly fields, which a property-only lookup silently misses.
+    /// </remarks>
+    private static bool TryReadMember(Attribute retryAttribute, out object? value, params string[] memberNames)
+    {
+        Type attrType = retryAttribute.GetType();
+
+        foreach (string memberName in memberNames)
+        {
+            try
+            {
+                PropertyInfo? property = attrType.GetProperty(memberName, BindingFlags.Public | BindingFlags.Instance);
+                if (property != null && property.CanRead)
+                {
+                    value = property.GetValue(retryAttribute);
+                    return true;
+                }
+
+                FieldInfo? field = attrType.GetField(memberName, BindingFlags.Public | BindingFlags.Instance);
+                if (field != null)
+                {
+                    value = field.GetValue(retryAttribute);
+                    return true;
+                }
+            }
+            catch
+            {
+                // Ignore member access errors and continue with the next candidate name
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// The number of attempts recorded so far for a test identity, and the outcome of the last one.
+    /// </summary>
+    private sealed class AttemptRecord(int attemptNumber, TestOutcome outcome)
+    {
+        public int AttemptNumber { get; } = attemptNumber;
+
+        public TestOutcome Outcome { get; } = outcome;
     }
 }

--- a/src/Xping.Sdk.MSTest/Xping.Sdk.MSTest.csproj
+++ b/src/Xping.Sdk.MSTest/Xping.Sdk.MSTest.csproj
@@ -18,6 +18,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Xping.Sdk.MSTest.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.7.2" />
   </ItemGroup>

--- a/src/Xping.Sdk.MSTest/XpingTestBase.cs
+++ b/src/Xping.Sdk.MSTest/XpingTestBase.cs
@@ -11,6 +11,7 @@ using Xping.Sdk.Core.Attributes;
 using Xping.Sdk.Core.Exceptions;
 using Xping.Sdk.Core.Models.Builders;
 using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.MSTest.Retry;
 
 namespace Xping.Sdk.MSTest;
 
@@ -190,7 +191,11 @@ public abstract class XpingTestBase
             ResolveStackTrace(outcome, stackTrace, services.CaptureStackTraces);
 
         // Detect retry metadata first so the attempt number is available when claiming a position.
-        RetryMetadata? retryMetadata = services.RetryDetector.DetectRetryMetadata(context, outcome);
+        // The MSTest detector numbers attempts by counting the executions already recorded for this
+        // test identity, which is why it needs the fingerprint resolved above.
+        RetryMetadata? retryMetadata = services.RetryDetector is IMSTestRetryDetector retryDetector
+            ? retryDetector.DetectRetryMetadata(context, outcome, identity.TestFingerprint)
+            : services.RetryDetector.DetectRetryMetadata(context, outcome);
 
         // Create an execution context using ExecutionTracker.
         // Pass the attempt number so retried executions reuse the position of the first attempt.
@@ -294,16 +299,8 @@ public abstract class XpingTestBase
         return firstDotIndex >= 0 ? fullyQualifiedClassName.Substring(0, firstDotIndex) : fullyQualifiedClassName;
     }
 
-    private static string? GetExceptionType(TestContext context)
-    {
-        if (context.CurrentTestOutcome == UnitTestOutcome.Passed)
-            return null;
-
-        if (context.Properties.Keys is { Count: >0 } && context.Properties.Contains("ExceptionType"))
-            return context.Properties["ExceptionType"]?.ToString();
-
-        return null;
-    }
+    private static string? GetExceptionType(TestContext context) =>
+        GetTestException(context)?.GetType().FullName;
 
     private static (string? stackTrace, bool stackTraceOmitted) ResolveStackTrace(
         TestOutcome outcome,
@@ -322,26 +319,34 @@ public abstract class XpingTestBase
         return (normalizedStackTrace, false);
     }
 
-    private static string? GetErrorMessage(TestContext context)
+    private static string? GetErrorMessage(TestContext context) =>
+        GetTestException(context)?.Message;
+
+    private static string? GetStackTrace(TestContext context) =>
+        GetTestException(context)?.StackTrace;
+
+    /// <summary>
+    /// Returns the exception that failed the current test, or <see langword="null"/> when the test did
+    /// not fail with one.
+    /// </summary>
+    /// <remarks>
+    /// MSTest exposes the failure through <see cref="TestContext.TestException"/>, which it sets before
+    /// <c>[TestCleanup]</c> runs. It is never populated from <c>TestContext.Properties</c>, which holds
+    /// only the test name, the run directories, and any <c>[TestProperty]</c> or <c>DataRow</c> values.
+    /// Outcomes with no exception behind them — a timeout, an aborted run — leave it null.
+    /// </remarks>
+    private static Exception? GetTestException(TestContext context)
     {
         if (context.CurrentTestOutcome == UnitTestOutcome.Passed)
             return null;
 
-        if (context.Properties.Keys is { Count: >0 } && context.Properties.Contains("ExceptionMessage"))
-            return context.Properties["ExceptionMessage"]?.ToString();
+        Exception? exception = context.TestException;
 
-        return null;
-    }
-
-    private static string? GetStackTrace(TestContext context)
-    {
-        if (context.CurrentTestOutcome == UnitTestOutcome.Passed)
-            return null;
-
-        if (context.Properties.Keys is { Count: >0 } && context.Properties.Contains("StackTrace"))
-            return context.Properties["StackTrace"]?.ToString();
-
-        return null;
+        // Reflection-invoked test methods surface their failure wrapped; the wrapper's own message and
+        // stack trace describe the invocation, not the test, so report what the test actually threw.
+        return exception is TargetInvocationException { InnerException: not null } wrapper
+            ? wrapper.InnerException
+            : exception;
     }
 
     /// <summary>

--- a/tests/Xping.Sdk.MSTest.Tests/Retry/MSTestRetryAttemptTests.cs
+++ b/tests/Xping.Sdk.MSTest.Tests/Retry/MSTestRetryAttemptTests.cs
@@ -1,0 +1,238 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+using Xping.Sdk.Core.Models.Executions;
+using Xping.Sdk.Core.Services.Retry;
+
+namespace Xping.Sdk.MSTest.Tests.Retry;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xping.Sdk.MSTest.Retry;
+using Xunit;
+using Assert = Xunit.Assert;
+
+/// <summary>
+/// Tests for the attempt numbering the MSTest detector derives by counting the executions already
+/// recorded for a test identity.
+/// </summary>
+/// <remarks>
+/// MSTest re-runs <c>[TestInitialize]</c> / <c>[TestCleanup]</c> for every retried attempt, so the
+/// adapter records one execution per attempt but has nothing telling it which attempt it is. Counting
+/// per fingerprint supplies the number; these tests pin the rules that counting follows.
+/// </remarks>
+public sealed class MSTestRetryAttemptTests
+{
+    private static readonly int[] _sequentialAttempts = [1, 2, 3, 4];
+
+    private const string Fingerprint = "8a1c6f5b9d2e4c3a7f0b6e5d4c3b2a19";
+    private const string OtherFingerprint = "0f9e8d7c6b5a49382716059483726150";
+
+    private readonly IMSTestRetryDetector _detector = new MSTestRetryDetector();
+
+    public MSTestRetryAttemptTests()
+    {
+        RetryAttributeRegistry.RegisterCustomRetryAttribute("mstest", "FieldConfiguredRetry");
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_SecondExecutionOfSameTest_IsAttemptTwo()
+    {
+        var first = Detect(TestOutcome.Failed);
+        var second = Detect(TestOutcome.Passed);
+
+        Assert.NotNull(first);
+        Assert.Equal(1, first.AttemptNumber);
+        Assert.False(first.PassedOnRetry);
+
+        Assert.NotNull(second);
+        Assert.Equal(2, second.AttemptNumber);
+        Assert.True(second.PassedOnRetry);
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_RepeatedFailures_NumbersEveryAttempt()
+    {
+        Assert.Equal(1, Detect(TestOutcome.Failed)!.AttemptNumber);
+        Assert.Equal(2, Detect(TestOutcome.Failed)!.AttemptNumber);
+
+        var third = Detect(TestOutcome.Passed);
+
+        Assert.Equal(3, third!.AttemptNumber);
+        Assert.True(third.PassedOnRetry);
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_AfterAPassingAttempt_StartsANewChain()
+    {
+        // Two [DataRow] rows carrying identical values share a fingerprint. The second is a genuine
+        // repeat, not a retry of the first, and must not be reported as one.
+        Detect(TestOutcome.Passed);
+
+        var repeat = Detect(TestOutcome.Passed);
+
+        Assert.Equal(1, repeat!.AttemptNumber);
+        Assert.False(repeat.PassedOnRetry);
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_DifferentTests_AreCountedIndependently()
+    {
+        Detect(TestOutcome.Failed);
+        Detect(TestOutcome.Failed);
+
+        var other = Detect(TestOutcome.Passed, OtherFingerprint);
+
+        Assert.Equal(1, other!.AttemptNumber);
+        Assert.False(other.PassedOnRetry);
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_WithoutRetryAttribute_ReturnsNullAndCountsNothing()
+    {
+        var withoutRetry = Detect(TestOutcome.Failed, Fingerprint, nameof(RetriedTests.TestMethodWithoutRetry));
+        Assert.Null(withoutRetry);
+
+        // The un-retried test shared this fingerprint, so had it been counted the retried test would
+        // start at attempt 2.
+        Assert.Equal(1, Detect(TestOutcome.Failed)!.AttemptNumber);
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_WithPublishedAttemptNumber_PrefersThePublishedValue()
+    {
+        var testContext = CreateTestContext(nameof(RetriedTests.TestMethodWithRetry));
+        testContext.Properties["RetryAttempt"] = 4;
+
+        var result = _detector.DetectRetryMetadata(testContext, TestOutcome.Passed, Fingerprint);
+
+        Assert.Equal(4, result!.AttemptNumber);
+        Assert.True(result.PassedOnRetry);
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_WithoutAFingerprint_FallsBackToInference()
+    {
+        IRetryDetector<TestContext> detector = _detector;
+        var testContext = CreateTestContext(nameof(RetriedTests.TestMethodWithRetry));
+
+        // The fingerprint-less overload has no identity to count against, so repeated calls stay on
+        // attempt 1 unless the test itself publishes an attempt number.
+        Assert.Equal(1, detector.DetectRetryMetadata(testContext, TestOutcome.Failed)!.AttemptNumber);
+        Assert.Equal(1, detector.DetectRetryMetadata(testContext, TestOutcome.Passed)!.AttemptNumber);
+    }
+
+    [Fact]
+    public async Task DetectRetryMetadata_ForTestsRunningInParallel_KeepsEachChainCorrect()
+    {
+        const int testCount = 16;
+        const int attemptsPerTest = 4;
+
+        var fingerprints = Enumerable.Range(0, testCount).Select(i => $"fingerprint-{i}").ToArray();
+
+        var results = await Task.WhenAll(fingerprints.Select(fingerprint => Task.Run(() =>
+            Enumerable.Range(0, attemptsPerTest)
+                .Select(_ => Detect(TestOutcome.Failed, fingerprint)!.AttemptNumber)
+                .ToArray())));
+
+        foreach (int[] attempts in results)
+        {
+            Assert.Equal(_sequentialAttempts, attempts);
+        }
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_ReadsConfigurationDeclaredAsFields()
+    {
+        var testContext = CreateTestContext(nameof(RetriedTests.TestMethodWithFieldConfiguredRetry));
+
+        var result = _detector.DetectRetryMetadata(testContext, TestOutcome.Passed, Fingerprint);
+
+        Assert.NotNull(result);
+        Assert.Equal(7, result.MaxRetries);
+        Assert.Equal(TimeSpan.FromMilliseconds(250), result.DelayBetweenRetries);
+    }
+
+    [Fact]
+    public void DetectRetryMetadata_WithSuffixedAttributeName_MatchesTheRegistry()
+    {
+        // The registry entry is "RetryAttribute" while the attribute is used as [Retry]; both
+        // spellings have to resolve or the attribute is invisible to the detector.
+        Assert.True(RetryAttributeRegistry.IsRegisteredForFramework("mstest", "RetryAttribute"));
+        Assert.True(RetryAttributeRegistry.IsRegisteredForFramework("mstest", "Retry"));
+    }
+
+    private RetryMetadata? Detect(
+        TestOutcome outcome,
+        string fingerprint = Fingerprint,
+        string testName = nameof(RetriedTests.TestMethodWithRetry)) =>
+        _detector.DetectRetryMetadata(CreateTestContext(testName), outcome, fingerprint);
+
+    private static AttemptTestContext CreateTestContext(string testName) =>
+        new(testName, typeof(RetriedTests).FullName!);
+
+    /// <summary>
+    /// Minimal <see cref="TestContext"/> carrying only what the detector reads.
+    /// </summary>
+    private sealed class AttemptTestContext(string testName, string fullClassName) : TestContext
+    {
+#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member
+        public override System.Collections.IDictionary Properties { get; } = new Dictionary<string, object?>();
+#pragma warning restore CS8609
+
+        public override string TestName => testName;
+
+        public override string? FullyQualifiedTestClassName => fullClassName;
+
+        public override UnitTestOutcome CurrentTestOutcome => UnitTestOutcome.Passed;
+
+        public override void AddResultFile(string fileName) { }
+
+        public override void WriteLine(string? message) { }
+
+        public override void WriteLine(string format, params object?[]? args) { }
+
+        public override void Write(string? message) { }
+
+        public override void Write(string format, params object?[]? args) { }
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Class is used via reflection in tests")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisCorrectness", "MSTEST0003:Test method signature is invalid", Justification = "Test helper class used via reflection")]
+    private sealed class RetriedTests
+    {
+        public static void TestMethodWithoutRetry() { }
+
+        [Retry(3)]
+        public static void TestMethodWithRetry() { }
+
+        [FieldConfiguredRetry]
+        public static void TestMethodWithFieldConfiguredRetry() { }
+    }
+
+    /// <summary>
+    /// Stand-in for the community retry attributes that expose their configuration as properties.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    private sealed class RetryAttribute(int maxRetries) : Attribute
+    {
+        public int MaxRetries { get; } = maxRetries;
+    }
+
+    /// <summary>
+    /// Stand-in for the retry attributes that expose their configuration as public readonly fields,
+    /// which a property-only lookup silently misses.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    private sealed class FieldConfiguredRetryAttribute : Attribute
+    {
+        public readonly int MaxRetries = 7;
+
+        public readonly int DelayBetweenRetriesMs = 250;
+    }
+}

--- a/tests/Xping.Sdk.MSTest.Tests/XpingTestBaseFailureDetailsTests.cs
+++ b/tests/Xping.Sdk.MSTest.Tests/XpingTestBaseFailureDetailsTests.cs
@@ -1,0 +1,140 @@
+/*
+ * © 2025 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+namespace Xping.Sdk.MSTest.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
+using Assert = Xunit.Assert;
+
+/// <summary>
+/// Tests that failure details are read from <see cref="TestContext.TestException"/>.
+/// </summary>
+/// <remarks>
+/// These getters previously read <c>TestContext.Properties</c> keys that MSTest never defines, so
+/// every failed MSTest test recorded empty failure text.
+/// </remarks>
+public sealed class XpingTestBaseFailureDetailsTests
+{
+    [Fact]
+    public void GetErrorMessage_FailedTest_ReturnsTheExceptionMessage()
+    {
+        var context = FailedWith(new InvalidOperationException("boom"));
+
+        Assert.Equal("boom", Invoke<string>("GetErrorMessage", context));
+    }
+
+    [Fact]
+    public void GetExceptionType_FailedTest_ReturnsTheFullTypeName()
+    {
+        var context = FailedWith(new InvalidOperationException("boom"));
+
+        Assert.Equal("System.InvalidOperationException", Invoke<string>("GetExceptionType", context));
+    }
+
+    [Fact]
+    public void GetStackTrace_FailedTest_ReturnsTheExceptionStackTrace()
+    {
+        var context = FailedWith(Thrown(new InvalidOperationException("boom")));
+
+        var stackTrace = Invoke<string>("GetStackTrace", context);
+
+        Assert.NotNull(stackTrace);
+        Assert.Contains(nameof(Thrown), stackTrace, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Getters_UnwrapTheReflectionWrapperAroundTheTestsOwnException()
+    {
+        var inner = new InvalidOperationException("boom");
+        var context = FailedWith(new TargetInvocationException(inner));
+
+        Assert.Equal("boom", Invoke<string>("GetErrorMessage", context));
+        Assert.Equal("System.InvalidOperationException", Invoke<string>("GetExceptionType", context));
+    }
+
+    [Fact]
+    public void Getters_PassedTest_ReturnNull()
+    {
+        var context = new FailureTestContext(UnitTestOutcome.Passed, new InvalidOperationException("boom"));
+
+        Assert.Null(Invoke<string>("GetErrorMessage", context));
+        Assert.Null(Invoke<string>("GetExceptionType", context));
+        Assert.Null(Invoke<string>("GetStackTrace", context));
+    }
+
+    [Fact]
+    public void Getters_FailedTestWithoutAnException_ReturnNull()
+    {
+        // A timeout or an aborted run fails the test without an exception behind it.
+        var context = new FailureTestContext(UnitTestOutcome.Timeout, testException: null);
+
+        Assert.Null(Invoke<string>("GetErrorMessage", context));
+        Assert.Null(Invoke<string>("GetExceptionType", context));
+        Assert.Null(Invoke<string>("GetStackTrace", context));
+    }
+
+    private static FailureTestContext FailedWith(Exception exception) =>
+        new FailureTestContext(UnitTestOutcome.Failed, exception);
+
+    /// <summary>
+    /// Throws and catches the exception so that it carries a real stack trace.
+    /// </summary>
+    private static Exception Thrown(Exception exception)
+    {
+        try
+        {
+            throw exception;
+        }
+        catch (Exception caught)
+        {
+            return caught;
+        }
+    }
+
+    private static T? Invoke<T>(string methodName, TestContext context)
+        where T : class
+    {
+        MethodInfo method = typeof(XpingTestBase).GetMethod(
+                methodName,
+                BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"{methodName} method not found");
+
+        return (T?)method.Invoke(null, [context]);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="TestContext"/> exposing an outcome and the exception MSTest publishes for it.
+    /// </summary>
+    private sealed class FailureTestContext : TestContext
+    {
+        private readonly UnitTestOutcome _outcome;
+
+        public FailureTestContext(UnitTestOutcome outcome, Exception? testException)
+        {
+            _outcome = outcome;
+            TestException = testException;
+        }
+
+#pragma warning disable CS8609 // Nullability of reference types in return type doesn't match overridden member
+        public override System.Collections.IDictionary Properties { get; } = new Dictionary<string, object?>();
+#pragma warning restore CS8609
+
+        public override UnitTestOutcome CurrentTestOutcome => _outcome;
+
+        public override void AddResultFile(string fileName) { }
+
+        public override void WriteLine(string? message) { }
+
+        public override void WriteLine(string format, params object?[]? args) { }
+
+        public override void Write(string? message) { }
+
+        public override void Write(string format, params object?[]? args) { }
+    }
+}


### PR DESCRIPTION
The MSTest adapter now correctly records retry attempt numbers, addressing the issue where `RetryMetadata.AttemptNumber` was always 1 and `PassedOnRetry` was always false. This change ensures that the `RetryMasked` finding in `xping report` is no longer silent for MSTest suites.

The fix includes:

- Adjusting the registry lookup to ensure retry attributes are correctly identified without stripping the "Attribute" suffix.

- Implementing a mechanism to derive the attempt number by counting the executions already recorded for the same test fingerprint, leveraging MSTest's lifecycle that re-runs the entire test for each attempt.

- Updating error message retrieval to utilize `TestContext.TestException`, ensuring that failure messages are accurately reported.

This enhancement allows for better visibility of masked failures in reports, as tests that fail and pass on retry will now be recorded with distinct attempt numbers. Verified through end-to-end testing with a sample MSTest project.

Fixes #116