### PR TITLE
Fix #119: derive NUnit ExceptionType from ResultState

### DIFF
--- a/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
+++ b/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
@@ -281,7 +281,7 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
     /// <summary>
     /// Determines the exception type for a completed test from its <see cref="ResultState"/>.
     /// </summary>
-    /// <param name="outcome">The NUnit result state of the test.</param>
+    /// <param name="outcome">The NUnit result state of the test, if one was recorded.</param>
     /// <param name="message">The NUnit failure message, if any.</param>
     /// <returns>The full exception type name, or <c>null</c> when NUnit records no type.</returns>
     /// <remarks>
@@ -291,7 +291,7 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
     /// from the message. Only the error arm carries a type name in its text.
     /// </para>
     /// </remarks>
-    internal static string? ExtractExceptionType(ResultState outcome, string? message)
+    internal static string? ExtractExceptionType(ResultState? outcome, string? message)
     {
         if (outcome is null || outcome.Status != TestStatus.Failed)
         {

--- a/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
+++ b/src/Xping.Sdk.NUnit/XpingTrackAttribute.cs
@@ -33,7 +33,23 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
 {
     private const string StartTimeKey = "Xping.StartTime";
     private const string StartTimestampKey = "Xping.StartTimestamp";
+
+    // Header NUnit writes for an Assert.Multiple failure. Identical in NUnit 3.14 and 4.x.
+    private const string MultipleFailureHeader = "Multiple failures or warnings in test:";
+
+    // NUnit prefixes a setup or teardown failure with "SetUp : " / "TearDown : ", so at most the
+    // first two segments of the line can hold the type name.
+    private const int MaxTypeSegmentsScanned = 2;
+
     private static readonly string[] _lineSeparators = ["\r\n", "\r", "\n"];
+
+    // Separator ExceptionHelper.BuildMessage places between the type name and the message.
+    private static readonly string[] _typeMessageSeparators = [" : "];
+
+    private static readonly string _assertionExceptionTypeName = typeof(AssertionException).FullName!;
+
+    private static readonly string _multipleAssertExceptionTypeName =
+        typeof(MultipleAssertException).FullName!;
 
     // Resolved once in BeforeTest() and reused for every AfterTest() on this attribute instance.
     // The attribute can be applied at assembly, class, or method scope; in all cases the same
@@ -232,7 +248,7 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
             .WithStartTime(startTime)
             .WithEndTime(endTime)
             .WithMetadata(metadata)
-            .WithException(ExtractExceptionType(result), errorMessage, configuredStackTrace)
+            .WithException(ExtractExceptionType(result.Outcome, result.Message), errorMessage, configuredStackTrace)
             .WithErrorMessageHash(services.IdentityGenerator.GenerateErrorMessageHash(errorMessage))
             .WithStackTraceHash(services.IdentityGenerator.GenerateStackTraceHash(configuredStackTrace))
             .WithStackTraceOmitted(stackTraceOmitted)
@@ -262,44 +278,99 @@ public sealed class XpingTrackAttribute : Attribute, ITestAction
         return (stackTrace, false);
     }
 
-    private static string? ExtractExceptionType(TestContext.ResultAdapter result)
+    /// <summary>
+    /// Determines the exception type for a completed test from its <see cref="ResultState"/>.
+    /// </summary>
+    /// <param name="outcome">The NUnit result state of the test.</param>
+    /// <param name="message">The NUnit failure message, if any.</param>
+    /// <returns>The full exception type name, or <c>null</c> when NUnit records no type.</returns>
+    /// <remarks>
+    /// <para>
+    /// <see cref="ITestAction.AfterTest(ITest)"/> only receives <see cref="TestContext.ResultAdapter"/>,
+    /// which exposes no exception object, so the type is derived from the outcome rather than guessed
+    /// from the message. Only the error arm carries a type name in its text.
+    /// </para>
+    /// </remarks>
+    internal static string? ExtractExceptionType(ResultState outcome, string? message)
     {
-        // NUnit 3 doesn't expose the exception type directly through the public API.
-        // We need to parse it from the message or stack trace
-        if (result.Outcome.Status == TestStatus.Passed)
+        if (outcome is null || outcome.Status != TestStatus.Failed)
+        {
+            // Passed, Skipped, Inconclusive and Warning results carry no exception type.
+            return null;
+        }
+
+        // Assertion failures: NUnit throws AssertionException and writes only the assertion text
+        // into the message, so there is nothing to parse and nothing worth guessing.
+        // Matches() compares Status and Label while ignoring Site, so SetUpFailure lands here too.
+        if (outcome.Matches(ResultState.Failure))
+        {
+            if (outcome.Site == FailureSite.Child)
+            {
+                // A suite rollup: the failing type belongs to a child test, not to this one.
+                return null;
+            }
+
+            // Assert.Multiple throws MultipleAssertException, which is a sibling of
+            // AssertionException rather than a subclass. The header is the only way to tell them apart.
+            return StartsWithMultipleFailureHeader(message)
+                ? _multipleAssertExceptionTypeName
+                : _assertionExceptionTypeName;
+        }
+
+        // Unhandled exceptions: NUnit builds these messages with ExceptionHelper.BuildMessage,
+        // which writes "{FullTypeName} : {message}". This is the only arm that encodes a real type.
+        if (outcome.Matches(ResultState.Error))
+        {
+            return ParseExceptionTypeFromErrorMessage(message);
+        }
+
+        // Cancelled, NotRunnable and any future label: no type is known.
+        return null;
+    }
+
+    private static bool StartsWithMultipleFailureHeader(string? message) =>
+        message != null &&
+        message.TrimStart().StartsWith(MultipleFailureHeader, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Reads the exception type out of a message NUnit formatted as "{FullTypeName} : {message}".
+    /// </summary>
+    private static string? ParseExceptionTypeFromErrorMessage(string? message)
+    {
+        if (string.IsNullOrEmpty(message))
         {
             return null;
         }
 
-        // Try to extract from the message - often contains an exception type
-        var message = result.Message;
-        if (!string.IsNullOrEmpty(message))
+        // Non-null after the check above.
+        var lines = message!.Split(_lineSeparators, StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length == 0)
         {
-            // Non-null after the check above
-            var lines = message!.Split(_lineSeparators, StringSplitOptions.RemoveEmptyEntries);
-            if (lines.Length > 0)
+            return null;
+        }
+
+        var segments = lines[0].Trim().Split(_typeMessageSeparators, StringSplitOptions.None);
+
+        // The last segment is the message body: a type token has to be followed by " : ".
+        // Scanning the leading segments only lets a "SetUp : {type} : {message}" prefix through
+        // without hunting for type-shaped words deep inside the prose.
+        var limit = Math.Min(segments.Length - 1, MaxTypeSegmentsScanned);
+        for (var i = 0; i < limit; i++)
+        {
+            var candidate = segments[i].Trim();
+            if (IsExceptionTypeName(candidate))
             {
-                var firstLine = lines[0].Trim();
-                // Check if it looks like an exception type (contains namespace and ends with Exception)
-                if (firstLine.Contains('.') && firstLine.Contains("Exception"))
-                {
-                    // Extract just the exception type, not the full message
-                    var colonIndex = firstLine.IndexOf(':');
-                    if (colonIndex > 0)
-                    {
-                        return firstLine.Substring(0, colonIndex).Trim();
-                    }
-                    // If no colon, the whole line might be the exception type
-                    if (!firstLine.Contains(' '))
-                    {
-                        return firstLine;
-                    }
-                }
+                return candidate;
             }
         }
 
         return null;
     }
+
+    private static bool IsExceptionTypeName(string candidate) =>
+        candidate.Length > 0 &&
+        candidate.IndexOf('.') > 0 &&
+        candidate.IndexOf(' ') < 0;
 
     private static TestOutcome MapOutcome(ResultState resultState)
     {

--- a/tests/Xping.Sdk.NUnit.Tests/XpingTrackAttributeExceptionTypeTests.cs
+++ b/tests/Xping.Sdk.NUnit.Tests/XpingTrackAttributeExceptionTypeTests.cs
@@ -5,11 +5,8 @@
 
 namespace Xping.Sdk.NUnit.Tests;
 
-using global::NUnit.Framework;
 using global::NUnit.Framework.Interfaces;
 using Xunit;
-using Assert = Xunit.Assert;
-using Theory = Xunit.TheoryAttribute;
 
 /// <summary>
 /// Tests for <see cref="XpingTrackAttribute.ExtractExceptionType"/>.
@@ -220,6 +217,6 @@ public sealed class XpingTrackAttributeExceptionTypeTests
     [Fact]
     public void ExtractExceptionType_NullOutcome_ReturnsNull()
     {
-        Assert.Null(XpingTrackAttribute.ExtractExceptionType(null!, "System.InvalidOperationException : boom"));
+        Assert.Null(XpingTrackAttribute.ExtractExceptionType(null, "System.InvalidOperationException : boom"));
     }
 }

--- a/tests/Xping.Sdk.NUnit.Tests/XpingTrackAttributeExceptionTypeTests.cs
+++ b/tests/Xping.Sdk.NUnit.Tests/XpingTrackAttributeExceptionTypeTests.cs
@@ -1,0 +1,225 @@
+/*
+ * © 2026 Xping.io. All Rights Reserved.
+ * License: [MIT]
+ */
+
+namespace Xping.Sdk.NUnit.Tests;
+
+using global::NUnit.Framework;
+using global::NUnit.Framework.Interfaces;
+using Xunit;
+using Assert = Xunit.Assert;
+using Theory = Xunit.TheoryAttribute;
+
+/// <summary>
+/// Tests for <see cref="XpingTrackAttribute.ExtractExceptionType"/>.
+/// The message strings below are the real ones NUnit produces for each failure shape.
+/// </summary>
+public sealed class XpingTrackAttributeExceptionTypeTests
+{
+    private const string AssertionExceptionName = "NUnit.Framework.AssertionException";
+    private const string MultipleAssertExceptionName = "NUnit.Framework.MultipleAssertException";
+
+    // ----- Assertion failures -----
+
+    [Fact]
+    public void ExtractExceptionType_AssertThatFailure_ReturnsAssertionException()
+    {
+        var message =
+            "  Assert.That(1 + 1, Is.EqualTo(3))\n" +
+            "  Expected: 3\n" +
+            "  But was:  2\n";
+
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.Failure, message);
+
+        Assert.Equal(AssertionExceptionName, exceptionType);
+    }
+
+    [Fact]
+    public void ExtractExceptionType_AssertThrowsFailure_ReturnsAssertionException()
+    {
+        // A failing Assert.Throws reports the assertion expression, not the exception it caught.
+        var message =
+            "  Assert.That(caughtException, expression)\n" +
+            "  Expected: <System.InvalidOperationException>\n" +
+            "  But was:  <System.ArgumentException: wrong type>\n";
+
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.Failure, message);
+
+        Assert.Equal(AssertionExceptionName, exceptionType);
+    }
+
+    [Fact]
+    public void ExtractExceptionType_AssertionMessageLooksLikeExceptionType_DoesNotReturnUserProse()
+    {
+        // Regression for #119: NUnit places the user-supplied message before the expression line.
+        var message =
+            "  Config error: System.IO.IOException was not handled\n" +
+            "  Assert.That(1 + 1, Is.EqualTo(3))\n" +
+            "  Expected: 3\n" +
+            "  But was:  2\n";
+
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.Failure, message);
+
+        Assert.Equal(AssertionExceptionName, exceptionType);
+    }
+
+    [Fact]
+    public void ExtractExceptionType_FlakyTestAssertionMessage_ReturnsAssertionException()
+    {
+        // Real message recorded from FlakyTest_RandomFailure_FailsProbabilistically.
+        var message =
+            "  Watchdog (106 ms) fired before the simulated service responded (190 ms). This reproduces\n" +
+            "  flakiness caused by network timeouts, service-side back-pressure, or CPU contention that\n" +
+            "  shifts task-scheduling order.\n" +
+            "Assert.That(winner == serviceCall, Is.True)\n" +
+            "  Expected: True\n" +
+            "  But was:  False\n";
+
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.Failure, message);
+
+        Assert.Equal(AssertionExceptionName, exceptionType);
+    }
+
+    [Fact]
+    public void ExtractExceptionType_MultipleAssertFailure_ReturnsMultipleAssertException()
+    {
+        var message =
+            "Multiple failures or warnings in test:\n" +
+            "  1) Expected: 3\n" +
+            "  But was:  2\n" +
+            "  2) Expected: True\n" +
+            "  But was:  False\n";
+
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.Failure, message);
+
+        Assert.Equal(MultipleAssertExceptionName, exceptionType);
+    }
+
+    [Fact]
+    public void ExtractExceptionType_SetUpFailure_ReturnsAssertionException()
+    {
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(
+            ResultState.SetUpFailure, "  Assert.That(config, Is.Not.Null)");
+
+        Assert.Equal(AssertionExceptionName, exceptionType);
+    }
+
+    [Fact]
+    public void ExtractExceptionType_FailureWithoutMessage_ReturnsAssertionException()
+    {
+        Assert.Equal(AssertionExceptionName, XpingTrackAttribute.ExtractExceptionType(ResultState.Failure, null));
+        Assert.Equal(
+            AssertionExceptionName, XpingTrackAttribute.ExtractExceptionType(ResultState.Failure, string.Empty));
+    }
+
+    [Fact]
+    public void ExtractExceptionType_ChildFailure_ReturnsNull()
+    {
+        // A suite rollup: the failing type belongs to a child test, not to this one.
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(
+            ResultState.ChildFailure, "One or more child tests had errors");
+
+        Assert.Null(exceptionType);
+    }
+
+    // ----- Unhandled exceptions -----
+
+    [Fact]
+    public void ExtractExceptionType_UnhandledException_ReturnsFullTypeName()
+    {
+        var message = "System.InvalidOperationException : This is a test exception for tracking purposes.";
+
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.Error, message);
+
+        Assert.Equal("System.InvalidOperationException", exceptionType);
+    }
+
+    [Fact]
+    public void ExtractExceptionType_SetUpError_SkipsSetUpPrefix()
+    {
+        var message = "SetUp : System.InvalidOperationException : Database was unreachable";
+
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.SetUpError, message);
+
+        Assert.Equal("System.InvalidOperationException", exceptionType);
+    }
+
+    [Fact]
+    public void ExtractExceptionType_TearDownError_SkipsTearDownPrefix()
+    {
+        var message = "TearDown : System.IO.IOException : The file is locked";
+
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.TearDownError, message);
+
+        Assert.Equal("System.IO.IOException", exceptionType);
+    }
+
+    [Fact]
+    public void ExtractExceptionType_CustomTypeWithoutExceptionSuffix_ReturnsFullTypeName()
+    {
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.Error, "MyLib.Fault : boom");
+
+        Assert.Equal("MyLib.Fault", exceptionType);
+    }
+
+    [Fact]
+    public void ExtractExceptionType_ErrorMessageWithStackTraceLines_ReadsFirstLineOnly()
+    {
+        var message =
+            "System.ArgumentException : Value does not fall within the expected range.\r\n" +
+            "   at SampleApp.NUnit.SampleTests.ThrowingTest()\r\n";
+
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.Error, message);
+
+        Assert.Equal("System.ArgumentException", exceptionType);
+    }
+
+    [Theory]
+    [InlineData("Something went wrong")]                       // no separator at all
+    [InlineData("Config error : plain prose here")]            // token before the separator has spaces
+    [InlineData("Timeout : the operation timed out")]          // token before the separator is not dotted
+    [InlineData("")]
+    [InlineData(null)]
+    public void ExtractExceptionType_ErrorWithoutTypeShapedToken_ReturnsNull(string? message)
+    {
+        var exceptionType = XpingTrackAttribute.ExtractExceptionType(ResultState.Error, message);
+
+        Assert.Null(exceptionType);
+    }
+
+    // ----- Non-failed and unclassified outcomes -----
+
+    [Fact]
+    public void ExtractExceptionType_PassedTest_ReturnsNull()
+    {
+        Assert.Null(XpingTrackAttribute.ExtractExceptionType(ResultState.Success, null));
+    }
+
+    [Fact]
+    public void ExtractExceptionType_NonFailedOutcomes_ReturnNull()
+    {
+        // A skipped or inconclusive test can still carry a message that looks like a type.
+        const string message = "System.InvalidOperationException : looks like a type but is not one";
+
+        Assert.Null(XpingTrackAttribute.ExtractExceptionType(ResultState.Skipped, message));
+        Assert.Null(XpingTrackAttribute.ExtractExceptionType(ResultState.Ignored, message));
+        Assert.Null(XpingTrackAttribute.ExtractExceptionType(ResultState.Explicit, message));
+        Assert.Null(XpingTrackAttribute.ExtractExceptionType(ResultState.Inconclusive, message));
+    }
+
+    [Fact]
+    public void ExtractExceptionType_CancelledOrNotRunnable_ReturnsNull()
+    {
+        const string message = "System.InvalidOperationException : looks like a type but is not one";
+
+        Assert.Null(XpingTrackAttribute.ExtractExceptionType(ResultState.Cancelled, message));
+        Assert.Null(XpingTrackAttribute.ExtractExceptionType(ResultState.NotRunnable, message));
+    }
+
+    [Fact]
+    public void ExtractExceptionType_NullOutcome_ReturnsNull()
+    {
+        Assert.Null(XpingTrackAttribute.ExtractExceptionType(null!, "System.InvalidOperationException : boom"));
+    }
+}


### PR DESCRIPTION
The NUnit adapter previously guessed the exception type by parsing the first line of NUnit's failure message, which resulted in null for every assertion failure and could incorrectly record fragments of user-supplied messages as the type. This update derives the exception type directly from the ResultState instead.

- For assertion failures (Failure/SetUpFailure), it now records `NUnit.Framework.AssertionException` or `MultipleAssertException` when applicable, without any parsing.

- For unhandled exceptions (Error/SetUpError/TearDownError), it parses the message using a stricter format that requires a " : " separator and a valid type token.

- Non-failed outcomes (ChildFailure, Cancelled, NotRunnable) will return null.

The `ExtractExceptionType` method is now internal and directly tested with real NUnit message strings. This change ensures accurate exception type recording and eliminates false positives.

Fixes #119